### PR TITLE
2 typos; hyphenate compound adjectives; RedHat → Red Hat

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Java Web Start (JWS) was deprecated in Java 9, and starting with Java 11, Oracle
 This means that clients that have the latest version of Java installed can no longer use JWS-based applications.
 And since public support of Java 8 has ended in Q2/2019, companies no longer get any updates and security fixes for Java Web Start.
 
-OpenWebStart offers a user friendly installer to use Web Start / JNLP functionality with future Java versions without depending on a specific Java vendor or distribution.
+OpenWebStart offers a user-friendly installer to use Web Start / JNLP functionality with future Java versions without depending on a specific Java vendor or distribution.
 The first goal of the project is to target Java 8 LTS versions while support for Java 11 LTS will come in near future.
 
-While we ([Karakun](https://dev.karakun.com)) develop user friendly installers to use a Java vendor independ approach for Web Start, we also help to integrate Web Start functionally in the Java 8 LTS releases of AdoptOpenJDK.
-Therefor all Web Start functionality is developed in the [IcedTea-Web](https://github.com/AdoptOpenJDK/IcedTea-Web) repository of the AdoptOpenJDK organization together with RedHat and other members of the AdoptOpenJDK community.
-Therefore this repository only contains sources that are needed to create enterprise ready and user friendly native installers for OpenWebStart.
+While we ([Karakun](https://dev.karakun.com)) develop user-friendly installers to use a Java vendor–independent approach for Web Start, we also help to integrate Web Start functionally in the Java 8 LTS releases of AdoptOpenJDK.
+Therefore all Web Start functionality is developed in the [IcedTea-Web](https://github.com/AdoptOpenJDK/IcedTea-Web) repository of the AdoptOpenJDK organization together with Red Hat and other members of the AdoptOpenJDK community.
+Therefore this repository only contains sources that are needed to create enterprise-ready and user-friendly native installers for OpenWebStart.
 
 ## License
 


### PR DESCRIPTION
I noticed a couple of typos and while I was in there couldn't resist hyphenating some compound adjectives.. feel free to take it or leave it..