### PR TITLE
initial config

### DIFF
--- a/openwebstart/src/main/java/com/openwebstart/install4j/Install4JConfiguration.java
+++ b/openwebstart/src/main/java/com/openwebstart/install4j/Install4JConfiguration.java
@@ -1,0 +1,74 @@
+package com.openwebstart.install4j;
+
+import com.install4j.api.launcher.Variables;
+import com.openwebstart.jvm.ui.dialogs.DialogFactory;
+import net.adoptopenjdk.icedteaweb.Assert;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class Install4JConfiguration {
+
+    private final static String LOCK_SUFFIX = ".locked";
+
+    private final static Install4JConfiguration INSTANCE = new Install4JConfiguration();
+
+    private final Lock installerVariableLock = new ReentrantLock();
+
+    private Install4JConfiguration() {
+    }
+
+    private Optional<Object> getInstallerVariable​(final String variableName) {
+        Assert.requireNonBlank(variableName, "variableName");
+        installerVariableLock.lock();
+        try {
+            final Object value = Variables.getInstallerVariable(variableName);
+            return Optional.ofNullable(value);
+        } finally {
+            installerVariableLock.unlock();
+        }
+    }
+
+    public Optional<String> getInstallerVariableAsString​(final String variableName) {
+        return getInstallerVariable​(variableName).map(v -> v.toString());
+    }
+
+    public Optional<Boolean> getInstallerVariableAsBoolean​(final String variableName) {
+        return getInstallerVariableAsString​(variableName).map(v -> Boolean.parseBoolean(v));
+    }
+
+    public Optional<Integer> getInstallerVariableAsInt​(final String variableName) {
+        return getInstallerVariableAsString​(variableName).map(v -> Integer.parseInt(v));
+    }
+
+    public Optional<Long> getInstallerVariableAsLong​(final String variableName) {
+        return getInstallerVariableAsString​(variableName).map(v -> Long.parseLong(v));
+    }
+
+    public String getInstallerVariableAsString​(final String variableName, final String defaultValue) {
+        return getInstallerVariableAsString​(variableName).orElse(defaultValue);
+    }
+
+    public boolean getInstallerVariableAsBoolean​(final String variableName, final boolean defaultValue) {
+        return getInstallerVariableAsBoolean​(variableName).orElse(defaultValue);
+    }
+
+    public int getInstallerVariableAsInt​(final String variableName, final int defaultValue) {
+        return getInstallerVariableAsInt​(variableName).orElse(defaultValue);
+    }
+
+    public long getInstallerVariableAsLong​(final String variableName, final long defaultValue) {
+        return getInstallerVariableAsLong​(variableName).orElse(defaultValue);
+    }
+
+    public boolean isVariableLocked(final String variableName) {
+        return getInstallerVariableAsBoolean​(variableName + LOCK_SUFFIX, false);
+    }
+
+    public static Install4JConfiguration getInstance() {
+        return INSTANCE;
+    }
+}

--- a/openwebstart/src/main/java/com/openwebstart/install4j/Install4JUtils.java
+++ b/openwebstart/src/main/java/com/openwebstart/install4j/Install4JUtils.java
@@ -17,7 +17,7 @@ public class Install4JUtils {
         try {
             return Optional.ofNullable(Variables.getCompilerVariable(VERSION_VARIABLE_NAME));
         } catch (IOException e) {
-            LOG.error("Can not read application applicationVersion", e);
+            LOG.warn("Can not read application applicationVersion");
             return Optional.empty();
         }
     }

--- a/openwebstart/src/main/java/com/openwebstart/jvm/ui/RuntimeManagerPanel.java
+++ b/openwebstart/src/main/java/com/openwebstart/jvm/ui/RuntimeManagerPanel.java
@@ -49,6 +49,7 @@ public final class RuntimeManagerPanel extends JPanel {
 
     public RuntimeManagerPanel(final DeploymentConfiguration deploymentConfiguration) {
         translator = Translator.getInstance();
+
         RuntimeManagerConfig.setConfiguration(deploymentConfiguration);
         JavaRuntimeManager.reloadLocalRuntimes();
         final RuntimeListActionSupplier supplier = new RuntimeListActionSupplier((oldValue, newValue) -> backgroundExecutor.execute(() -> LocalRuntimeManager.getInstance().replace(oldValue, newValue)));
@@ -78,7 +79,7 @@ public final class RuntimeManagerPanel extends JPanel {
         }));
 
         final JButton configureButton = new JButton(translator.translate("jvmManager.action.settings.text"));
-        configureButton.addActionListener(e -> new ConfigurationDialog().showAndWait());
+        configureButton.addActionListener(e -> new ConfigurationDialog(deploymentConfiguration).showAndWait());
 
         final JButton addLocalRuntimesButton = new JButton(translator.translate("jvmManager.action.addLocal.text"));
         addLocalRuntimesButton.addActionListener(e -> {

--- a/openwebstart/src/main/java/com/openwebstart/launcher/ControlPanelLauncher.java
+++ b/openwebstart/src/main/java/com/openwebstart/launcher/ControlPanelLauncher.java
@@ -22,15 +22,25 @@ public class ControlPanelLauncher {
 
         Translator.addBundle("i18n");
         final DeploymentConfiguration config = new DeploymentConfiguration();
+
         try {
             config.load();
         } catch (final ConfigurationException e) {
             DialogFactory.showErrorDialog(Translator.getInstance().translate("error.loadConfig"), e);
+            System.exit(-1);
+        }
+
+        try {
+            new InitialConfigurationCheck(config).check();
+        } catch (Exception e) {
+            DialogFactory.showErrorDialog(Translator.getInstance().translate("error.initialConfig"), e);
+            System.exit(-1);
         }
 
         try {
             UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-        } catch (Exception ignored) {
+        } catch (final Exception e) {
+            LOG.error("Can not set look&feel", e);
         }
 
         SwingUtils.invokeLater(() -> {

--- a/openwebstart/src/main/java/com/openwebstart/launcher/InitialConfigurationCheck.java
+++ b/openwebstart/src/main/java/com/openwebstart/launcher/InitialConfigurationCheck.java
@@ -34,14 +34,11 @@ public class InitialConfigurationCheck {
 
     private final DeploymentConfiguration deploymentConfiguration;
 
-    private final UiLock uiLock;
-
     private final Lock preferencesStoreLock = new ReentrantLock();
 
     public InitialConfigurationCheck(final DeploymentConfiguration deploymentConfiguration) {
         this.deploymentConfiguration = Assert.requireNonNull(deploymentConfiguration, "deploymentConfiguration");
         this.install4JConfiguration = Install4JConfiguration.getInstance();
-        this.uiLock = new UiLock(deploymentConfiguration);
     }
 
     public void check() throws Exception {
@@ -81,7 +78,7 @@ public class InitialConfigurationCheck {
 
         if (install4JConfiguration.isVariableLocked(propertyName)) {
             LOG.info("Property '{}' will be locked", propertyName);
-            uiLock.addLock(propertyName);
+            deploymentConfiguration.lock(propertyName);
         } else {
             LOG.info("no lock defined for property '{}'", propertyName);
         }

--- a/openwebstart/src/main/java/com/openwebstart/launcher/InitialConfigurationCheck.java
+++ b/openwebstart/src/main/java/com/openwebstart/launcher/InitialConfigurationCheck.java
@@ -1,0 +1,111 @@
+package com.openwebstart.launcher;
+
+import com.openwebstart.install4j.Install4JConfiguration;
+import net.adoptopenjdk.icedteaweb.Assert;
+import net.adoptopenjdk.icedteaweb.client.util.UiLock;
+import net.adoptopenjdk.icedteaweb.logging.Logger;
+import net.adoptopenjdk.icedteaweb.logging.LoggerFactory;
+import net.sourceforge.jnlp.config.DeploymentConfiguration;
+
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static com.openwebstart.config.OwsDefaultsProvider.ALLOW_DOWNLOAD_SERVER_FROM_JNLP;
+import static com.openwebstart.config.OwsDefaultsProvider.DEFAULT_JVM_DOWNLOAD_SERVER;
+import static com.openwebstart.config.OwsDefaultsProvider.JVM_SUPPORTED_VERSION_RANGE;
+import static com.openwebstart.config.OwsDefaultsProvider.JVM_UPDATE_STRATEGY;
+import static com.openwebstart.config.OwsDefaultsProvider.JVM_VENDOR;
+import static net.sourceforge.jnlp.config.ConfigurationConstants.KEY_CACHE_COMPRESSION_ENABLED;
+import static net.sourceforge.jnlp.config.ConfigurationConstants.KEY_CACHE_MAX_SIZE;
+import static net.sourceforge.jnlp.config.ConfigurationConstants.KEY_PROXY_AUTO_CONFIG_URL;
+import static net.sourceforge.jnlp.config.ConfigurationConstants.KEY_PROXY_BYPASS_LOCAL;
+import static net.sourceforge.jnlp.config.ConfigurationConstants.KEY_PROXY_HTTP_HOST;
+import static net.sourceforge.jnlp.config.ConfigurationConstants.KEY_PROXY_HTTP_PORT;
+import static net.sourceforge.jnlp.config.ConfigurationConstants.KEY_PROXY_TYPE;
+
+public class InitialConfigurationCheck {
+
+    private final static Logger LOG = LoggerFactory.getLogger(InitialConfigurationCheck.class);
+
+    private final static String FIRST_START_VARIABLE_NAME = "com.karakun.openwebstart.config.initial.firstStart";
+
+    private final Install4JConfiguration install4JConfiguration;
+
+    private final DeploymentConfiguration deploymentConfiguration;
+
+    private final UiLock uiLock;
+
+    private final Lock preferencesStoreLock = new ReentrantLock();
+
+    public InitialConfigurationCheck(final DeploymentConfiguration deploymentConfiguration) {
+        this.deploymentConfiguration = Assert.requireNonNull(deploymentConfiguration, "deploymentConfiguration");
+        this.install4JConfiguration = Install4JConfiguration.getInstance();
+        this.uiLock = new UiLock(deploymentConfiguration);
+    }
+
+    public void check() throws Exception {
+        if (isFirstStart()) {
+            LOG.info("Looks like OpenWebStart is started for the first time. Will import initial configuration");
+
+            initProperty(DEFAULT_JVM_DOWNLOAD_SERVER);
+            initProperty(ALLOW_DOWNLOAD_SERVER_FROM_JNLP);
+            initProperty(JVM_VENDOR);
+            initProperty(JVM_UPDATE_STRATEGY);
+            initProperty(JVM_SUPPORTED_VERSION_RANGE);
+            initProperty(KEY_PROXY_HTTP_HOST);
+            initProperty(KEY_PROXY_HTTP_PORT);
+            initProperty(KEY_PROXY_BYPASS_LOCAL);
+            initProperty(KEY_PROXY_TYPE);
+            initProperty(KEY_PROXY_AUTO_CONFIG_URL);
+            initProperty(KEY_CACHE_MAX_SIZE);
+            initProperty(KEY_CACHE_COMPRESSION_ENABLED);
+
+            deploymentConfiguration.save();
+
+            setFirstStartDoneFlag();
+            LOG.info("Import of initial configuration done");
+        }
+    }
+
+    private void initProperty(final String propertyName) {
+        Assert.requireNonBlank(propertyName, "propertyName");
+
+        LOG.info("Checking if property '{}' is predefined", propertyName);
+
+        install4JConfiguration.getInstallerVariableAsString​(propertyName)
+                .ifPresent(v -> {
+                    LOG.info("Property '{}' will be imported with value '{}'", propertyName, v);
+                    deploymentConfiguration.setProperty(propertyName, v);
+                });
+
+        if (install4JConfiguration.isVariableLocked(propertyName)) {
+            LOG.info("Property '{}' will be locked", propertyName);
+            uiLock.addLock(propertyName);
+        } else {
+            LOG.info("no lock defined for property '{}'", propertyName);
+        }
+    }
+
+    public boolean isFirstStart() {
+        preferencesStoreLock.lock();
+        try {
+            final boolean value = Optional.ofNullable(deploymentConfiguration.getProperty(FIRST_START_VARIABLE_NAME))
+                    .map(s -> Boolean.parseBoolean(s))
+                    .orElse(true);
+            return value;
+        } finally {
+            preferencesStoreLock.unlock();
+        }
+    }
+
+    public void setFirstStartDoneFlag() throws Exception {
+        preferencesStoreLock.lock();
+        try {
+            deploymentConfiguration.setProperty(FIRST_START_VARIABLE_NAME, Boolean.FALSE.toString());
+            deploymentConfiguration.save();
+        } finally {
+            preferencesStoreLock.unlock();
+        }
+    }
+}

--- a/openwebstart/src/main/java/com/openwebstart/launcher/PhaseTwoWebStartLauncher.java
+++ b/openwebstart/src/main/java/com/openwebstart/launcher/PhaseTwoWebStartLauncher.java
@@ -9,9 +9,11 @@ import net.adoptopenjdk.icedteaweb.commandline.CommandLineOptions;
 import net.adoptopenjdk.icedteaweb.i18n.Translator;
 import net.adoptopenjdk.icedteaweb.logging.Logger;
 import net.adoptopenjdk.icedteaweb.logging.LoggerFactory;
+import net.sourceforge.jnlp.config.DeploymentConfiguration;
 import net.sourceforge.jnlp.runtime.Boot;
 import net.sourceforge.jnlp.runtime.JNLPRuntime;
 
+import javax.naming.ConfigurationException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,6 +37,21 @@ public class PhaseTwoWebStartLauncher {
         LOG.info("OpenWebStartLauncher called with args {}.", Arrays.toString(args));
         LOG.debug("OS detected: Win[{}], MacOS[{}], Linux[{}]",
                 InstallerUtil.isWindows(), InstallerUtil.isMacOS(), InstallerUtil.isLinux());
+
+        final DeploymentConfiguration config = new DeploymentConfiguration();
+        try {
+            config.load();
+        } catch (final ConfigurationException e) {
+            DialogFactory.showErrorDialog(Translator.getInstance().translate("error.loadConfig"), e);
+            System.exit(-1);
+        }
+
+        try {
+            new InitialConfigurationCheck(config).check();
+        } catch (Exception e) {
+            DialogFactory.showErrorDialog(Translator.getInstance().translate("error.initialConfig"), e);
+            System.exit(-1);
+        }
 
         final List<String> bootArgs = skipNotRelevantArgs(args);
         final JavaRuntimeProvider javaRuntimeProvider = JavaRuntimeManager.getJavaRuntimeProvider(


### PR DESCRIPTION
An initial configuration for several properties is extracted from the Install4J properties at the first start of IcedTeaWeb. All this properties directly support properties for the UI-Lock that is defined in https://github.com/AdoptOpenJDK/IcedTea-Web/pull/478

Since this PR is based on new functionality in ITW it should not be merged before https://github.com/AdoptOpenJDK/IcedTea-Web/pull/478 is merged!