### PR TITLE
Autoclean for unused runtimes

### DIFF
--- a/openwebstart/src/main/java/com/openwebstart/config/OwsDefaultsProvider.java
+++ b/openwebstart/src/main/java/com/openwebstart/config/OwsDefaultsProvider.java
@@ -25,6 +25,7 @@ public class OwsDefaultsProvider implements DefaultsProvider {
     public static final String JVM_VENDOR = "ows.jvm.manager.vendor";
     public static final String JVM_UPDATE_STRATEGY = "ows.jvm.manager.updateStrategy";
     public static final String JVM_SUPPORTED_VERSION_RANGE = "ows.jvm.manager.versionRange";
+    public static final String MAX_DAYS_UNUSED_IN_JVM_CACHE = "ows.jvm.manager.maxDaysUnusedInJvmCache";
 
     public static final String PROXY_PAC_CACHE = "deployment.proxy.pac.cache";
 
@@ -104,6 +105,11 @@ public class OwsDefaultsProvider implements DefaultsProvider {
                                         .map(Enum::name)
                                         .toArray(String[]::new)
                         )
+                ),
+                Setting.createDefault(
+                        MAX_DAYS_UNUSED_IN_JVM_CACHE,
+                        "30",
+                        ValidatorFactory.createRangedIntegerValidator(0, 3_650)
                 )
         );
     }

--- a/openwebstart/src/main/java/com/openwebstart/jvm/LocalRuntimeManager.java
+++ b/openwebstart/src/main/java/com/openwebstart/jvm/LocalRuntimeManager.java
@@ -30,6 +30,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -268,6 +269,20 @@ public final class LocalRuntimeManager {
                 throw new RuntimeException("Error while saving JVM cache.", e);
             }
         }
+    }
+
+    public static void touch(final LocalJavaRuntime currentRuntime) {
+        LocalJavaRuntime newRuntime = new LocalJavaRuntime(
+                currentRuntime.getVersion().toString(),
+                currentRuntime.getOperationSystem(),
+                currentRuntime.getVendor().toString(),
+                currentRuntime.getJavaHome(),
+                LocalDateTime.now(),
+                currentRuntime.isActive(),
+                currentRuntime.isManaged()
+        );
+
+        LocalRuntimeManager.getInstance().replace(currentRuntime, newRuntime);
     }
 
     public static LocalRuntimeManager getInstance() {

--- a/openwebstart/src/main/java/com/openwebstart/jvm/LocalRuntimeManager.java
+++ b/openwebstart/src/main/java/com/openwebstart/jvm/LocalRuntimeManager.java
@@ -146,12 +146,12 @@ public final class LocalRuntimeManager {
     private boolean isUnused(final LocalJavaRuntime localJavaRuntime) {
         final int maxDaysUnusedInJvmCache = RuntimeManagerConfig.getMaxDaysUnusedInJvmCache();
         final LocalDateTime lastUsage = localJavaRuntime.getLastUsage();
-            final LocalDateTime today = LocalDateTime.now();
-            if (lastUsage.plusDays(maxDaysUnusedInJvmCache).isBefore(today)) {
-                LOG.info(String.format("Delete unused runtime '%s' from JVM cache as it exceeds max number of %s days " +
-                        "allowed to stay in cache.", localJavaRuntime.getJavaHome(), maxDaysUnusedInJvmCache));
-                return true;
-            }
+        final LocalDateTime today = LocalDateTime.now();
+        if (lastUsage.plusDays(maxDaysUnusedInJvmCache).isBefore(today)) {
+            LOG.info("Delete unused runtime '{}' from JVM cache as it exceeds max number of {} days " +
+                    "allowed to stay in cache.", localJavaRuntime.getJavaHome(), maxDaysUnusedInJvmCache);
+            return true;
+        }
         return false;
     }
 

--- a/openwebstart/src/main/java/com/openwebstart/jvm/LocalRuntimeManager.java
+++ b/openwebstart/src/main/java/com/openwebstart/jvm/LocalRuntimeManager.java
@@ -55,7 +55,6 @@ public final class LocalRuntimeManager {
     private final List<RuntimeUpdateListener> updatedListeners = new CopyOnWriteArrayList<>();
 
     private final Lock jsonStoreLock = new ReentrantLock();
-    public static final int MAX_DAYS_STAY_IN_JVM_CACHE = 100;
 
     private LocalRuntimeManager() {
     }
@@ -145,11 +144,12 @@ public final class LocalRuntimeManager {
     }
 
     private boolean isUnused(final LocalJavaRuntime localJavaRuntime) {
-            final LocalDateTime lastUsage = localJavaRuntime.getLastUsage();
+        final int maxDaysUnusedInJvmCache = RuntimeManagerConfig.getMaxDaysUnusedInJvmCache();
+        final LocalDateTime lastUsage = localJavaRuntime.getLastUsage();
             final LocalDateTime today = LocalDateTime.now();
-            if (lastUsage.plusDays(MAX_DAYS_STAY_IN_JVM_CACHE).isBefore(today)) {
+            if (lastUsage.plusDays(maxDaysUnusedInJvmCache).isBefore(today)) {
                 LOG.info(String.format("Delete unused runtime '%s' from JVM cache as it exceeds max number of %s days " +
-                        "allowed to stay in cache.", localJavaRuntime.getJavaHome(), MAX_DAYS_STAY_IN_JVM_CACHE));
+                        "allowed to stay in cache.", localJavaRuntime.getJavaHome(), maxDaysUnusedInJvmCache));
                 return true;
             }
         return false;

--- a/openwebstart/src/main/java/com/openwebstart/jvm/RuntimeManagerConfig.java
+++ b/openwebstart/src/main/java/com/openwebstart/jvm/RuntimeManagerConfig.java
@@ -15,6 +15,7 @@ import static com.openwebstart.config.OwsDefaultsProvider.DEFAULT_UPDATE_STRATEG
 import static com.openwebstart.config.OwsDefaultsProvider.JVM_SUPPORTED_VERSION_RANGE;
 import static com.openwebstart.config.OwsDefaultsProvider.JVM_UPDATE_STRATEGY;
 import static com.openwebstart.config.OwsDefaultsProvider.JVM_VENDOR;
+import static com.openwebstart.config.OwsDefaultsProvider.MAX_DAYS_UNUSED_IN_JVM_CACHE;
 
 public class RuntimeManagerConfig {
 
@@ -53,6 +54,14 @@ public class RuntimeManagerConfig {
 
     public static String getVendor() {
         return config().getProperty(JVM_VENDOR);
+    }
+
+     public static int getMaxDaysUnusedInJvmCache() {
+        return Integer.parseInt(config().getProperty(MAX_DAYS_UNUSED_IN_JVM_CACHE));
+    }
+
+    public static void setMaxDaysUnusedInJvmCache(final String maxDaysUnusedInJvmCache) {
+        config().setProperty(MAX_DAYS_UNUSED_IN_JVM_CACHE, maxDaysUnusedInJvmCache);
     }
 
     public static void setDefaultVendor(final String defaultVendor) {

--- a/openwebstart/src/main/java/com/openwebstart/jvm/ui/LookAndFeel.java
+++ b/openwebstart/src/main/java/com/openwebstart/jvm/ui/LookAndFeel.java
@@ -1,0 +1,10 @@
+package com.openwebstart.jvm.ui;
+
+import java.awt.Color;
+
+/**
+ * Look and feel constants defining colors etc.
+ */
+public interface LookAndFeel {
+    Color FIELD_VALIDATION_PROBLEM = Color.orange;
+}

--- a/openwebstart/src/main/java/com/openwebstart/launcher/InitialConfigurationCheck.java
+++ b/openwebstart/src/main/java/com/openwebstart/launcher/InitialConfigurationCheck.java
@@ -19,6 +19,7 @@ import static com.openwebstart.config.OwsDefaultsProvider.DEFAULT_JVM_DOWNLOAD_S
 import static com.openwebstart.config.OwsDefaultsProvider.JVM_SUPPORTED_VERSION_RANGE;
 import static com.openwebstart.config.OwsDefaultsProvider.JVM_UPDATE_STRATEGY;
 import static com.openwebstart.config.OwsDefaultsProvider.JVM_VENDOR;
+import static com.openwebstart.config.OwsDefaultsProvider.MAX_DAYS_UNUSED_IN_JVM_CACHE;
 import static net.sourceforge.jnlp.config.ConfigurationConstants.KEY_ASSUME_FILE_STEM_IN_CODEBASE;
 import static net.sourceforge.jnlp.config.ConfigurationConstants.KEY_CACHE_COMPRESSION_ENABLED;
 import static net.sourceforge.jnlp.config.ConfigurationConstants.KEY_CACHE_MAX_SIZE;
@@ -67,6 +68,7 @@ class InitialConfigurationCheck {
             initProperty(KEY_HTTPS_DONT_ENFORCE);
             initProperty(KEY_ASSUME_FILE_STEM_IN_CODEBASE);
             initProperty(KEY_SECURITY_SERVER_WHITELIST);
+            initProperty(MAX_DAYS_UNUSED_IN_JVM_CACHE);
 
             initProperty(UpdatePanelConfigConstants.CHECK_FOR_UPDATED_PARAM_NAME);
             initProperty(UpdatePanelConfigConstants.CHECK_FOR_UPDATED_NOW_PARAM_NAME);

--- a/openwebstart/src/main/java/com/openwebstart/launcher/OwsJvmLauncher.java
+++ b/openwebstart/src/main/java/com/openwebstart/launcher/OwsJvmLauncher.java
@@ -1,6 +1,7 @@
 package com.openwebstart.launcher;
 
 import com.openwebstart.config.OwsDefaultsProvider;
+import com.openwebstart.jvm.JavaRuntimeManager;
 import com.openwebstart.jvm.LocalRuntimeManager;
 import com.openwebstart.jvm.runtimes.LocalJavaRuntime;
 import com.openwebstart.jvm.ui.dialogs.DialogFactory;
@@ -64,6 +65,9 @@ public class OwsJvmLauncher implements JvmLauncher {
         LOG.info("using java runtime at '{}' for launching managed application", runtimeInfo.runtime.getJavaHome());
         final File webStartJar = getOpenWebStartJar();
         launchExternal(runtimeInfo, webStartJar, args);
+
+        // reload to ensure unused runtime cleanup check happens regularly
+        JavaRuntimeManager.reloadLocalRuntimes();
     }
 
     private RuntimeInfo getLocalJavaRuntimeOrExit(final JNLPFile jnlpFile) {

--- a/openwebstart/src/main/java/com/openwebstart/launcher/OwsJvmLauncher.java
+++ b/openwebstart/src/main/java/com/openwebstart/launcher/OwsJvmLauncher.java
@@ -1,6 +1,7 @@
 package com.openwebstart.launcher;
 
 import com.openwebstart.config.OwsDefaultsProvider;
+import com.openwebstart.jvm.LocalRuntimeManager;
 import com.openwebstart.jvm.runtimes.LocalJavaRuntime;
 import com.openwebstart.jvm.ui.dialogs.DialogFactory;
 import com.openwebstart.jvm.util.JavaExecutableFinder;
@@ -130,7 +131,10 @@ public class OwsJvmLauncher implements JvmLauncher {
         } else {
             throw new RuntimeException("Java " + version + " is not supported");
         }
+
+        LocalRuntimeManager.getInstance().touch(javaRuntime);
     }
+
 
     private void launchExternal(
             final String pathToJavaBinary,

--- a/openwebstart/src/main/resources/i18n.properties
+++ b/openwebstart/src/main/resources/i18n.properties
@@ -174,5 +174,7 @@ dialog.jvmManagerConfig.vendor.text=Vendor:
 dialog.jvmManagerConfig.defaultServerUrl.text=Default update server URL:
 dialog.jvmManagerConfig.allowServerInJnlp.text=Allow server from JNLP file
 dialog.jvmManagerConfig.versionRange.text=Restrict JVM version range:
+dialog.jvmManagerConfig.unusedRuntimeCleanup.text=Delete unused JVMs from local cache after
+dialog.jvmManagerConfig.unusedRuntimeCleanup.days.text=days
 
 dialog.error.title=Error

--- a/openwebstart/src/main/resources/i18n_de.properties
+++ b/openwebstart/src/main/resources/i18n_de.properties
@@ -174,5 +174,8 @@ dialog.jvmManagerConfig.vendor.text=Hersteller:
 dialog.jvmManagerConfig.defaultServerUrl.text=Standard Server URL f\u00FCr Updates:
 dialog.jvmManagerConfig.allowServerInJnlp.text=Nutzung von Server aus JNLP Datei erlauben
 dialog.jvmManagerConfig.versionRange.text=Erlaubter Versionsbereich f\u00FCr JVMs:
+dialog.jvmManagerConfig.unusedRuntimeCleanup.text=L\u00F6sche ungenutzte JVMs im lokalen Cache nach
+dialog.jvmManagerConfig.unusedRuntimeCleanup.days.text=Tagen
+
 
 dialog.error.title=Fehler


### PR DESCRIPTION
- touch runtime when used by a launched jnlp application
- check for unused runtimes and do cleanup if necessary
- allow to configure max days for unused JVMs via OWS Settings UI