### PR TITLE
#248 remote debugging; configurable suspend option and random port option

### DIFF
--- a/openwebstart/src/main/java/com/openwebstart/config/OwsDefaultsProvider.java
+++ b/openwebstart/src/main/java/com/openwebstart/config/OwsDefaultsProvider.java
@@ -16,6 +16,8 @@ import java.util.stream.Stream;
 public class OwsDefaultsProvider implements DefaultsProvider {
 
     public static final String REMOTE_DEBUG = "ows.jvm.manager.remoteDebug";
+    public static final String START_SUSPENDED = "ows.jvm.manager.startSuspended";
+    public static final String RANDOM_DEBUG_PORT = "ows.jvm.manager.randomDebugPort";
     public static final String REMOTE_DEBUG_PORT = "ows.jvm.manager.remoteDebugPort";
     public static final String REMOTE_DEBUG_PORT_DEFAULT_VALUE = "5005";
 
@@ -49,6 +51,16 @@ public class OwsDefaultsProvider implements DefaultsProvider {
                 Setting.createDefault(
                         REMOTE_DEBUG,
                         Boolean.FALSE.toString(),
+                        ValidatorFactory.createBooleanValidator()
+                ),
+                Setting.createDefault(
+                        START_SUSPENDED,
+                        Boolean.FALSE.toString(),
+                        ValidatorFactory.createBooleanValidator()
+                ),
+                Setting.createDefault(
+                        RANDOM_DEBUG_PORT,
+                        Boolean.TRUE.toString(),
                         ValidatorFactory.createBooleanValidator()
                 ),
                 Setting.createDefault(

--- a/openwebstart/src/main/java/com/openwebstart/debug/DebugPanel.java
+++ b/openwebstart/src/main/java/com/openwebstart/debug/DebugPanel.java
@@ -2,6 +2,7 @@ package com.openwebstart.debug;
 
 import com.openwebstart.config.OwsDefaultsProvider;
 import com.openwebstart.controlpanel.FormPanel;
+import com.openwebstart.launcher.OwsJvmLauncher;
 import net.adoptopenjdk.icedteaweb.Assert;
 import net.adoptopenjdk.icedteaweb.client.util.UiLock;
 import net.adoptopenjdk.icedteaweb.i18n.Translator;
@@ -12,61 +13,176 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import java.util.function.Consumer;
 
 public class DebugPanel extends FormPanel {
+    final DeploymentConfiguration config;
+    final Translator translator;
+    final JCheckBox activateDebugCheckbox;
+    final JCheckBox startSuspendedCheckbox;
+    final JCheckBox anyPortCheckbox;
+    final JLabel debugPortLabel;
+    final JTextField debugPortField;
+    final JTextArea warningLabel;
+    final JTextArea messageLabel;
+
+    private void updateControlStatus() {
+        final boolean enabled = activateDebugCheckbox.isSelected();
+        final boolean usingSpecificPort = !anyPortCheckbox.isSelected();
+
+        startSuspendedCheckbox.setEnabled(enabled);
+        anyPortCheckbox.setEnabled(enabled);
+
+        debugPortLabel.setEnabled(enabled && usingSpecificPort);
+        debugPortField.setEnabled(enabled && usingSpecificPort);
+
+        warningLabel.setEnabled(enabled);
+
+        warningLabel.setVisible(enabled && usingSpecificPort);
+
+        messageLabel.setVisible(enabled);
+    }
+
+    private int getPortToBeUsed() throws Exception {
+        final String portAsString = debugPortField.getText();
+        final int port = Integer.parseInt(portAsString);
+        if (port <= 0) {
+            throw new Exception("Negative port number");
+        }
+        return port;
+    }
+
+    private void updateMessageLabel() {
+        final boolean useAnyPort = anyPortCheckbox.isSelected();
+        final boolean startSuspended = startSuspendedCheckbox.isSelected();
+
+        try {
+            // use the port only when needed
+            final int port = useAnyPort ? 0 : getPortToBeUsed();
+            String parameters = OwsJvmLauncher.getRemoteDebugParameters(useAnyPort,startSuspended,port);
+            messageLabel.setText(translator.translate("debugPanel.description.success", parameters));
+        } catch (final Exception ignore) {
+            final String lastValidValue = config.getProperty(OwsDefaultsProvider.REMOTE_DEBUG_PORT);
+
+            final int port = Integer.parseInt(lastValidValue);
+            String parameters = OwsJvmLauncher.getRemoteDebugParameters(useAnyPort,startSuspended,port);
+            messageLabel.setText(translator.translate("debugPanel.description.fail", parameters));
+        }
+    }
 
     public DebugPanel(final DeploymentConfiguration config) {
         Assert.requireNonNull(config, "deploymentConfiguration");
+        this.config = config;
 
-        final Translator translator = Translator.getInstance();
+        translator = Translator.getInstance();
         final UiLock uiLock = new UiLock(config);
+        int row = 0;
 
-        final JTextArea infoLabel = new JTextArea(translator.translate("debugPanel.info"));
+        JTextArea infoLabel = new JTextArea(translator.translate("debugPanel.info"));
         infoLabel.setEditable(false);
         infoLabel.setBackground(null);
         infoLabel.setWrapStyleWord(true);
         infoLabel.setLineWrap(true);
-        addRow(0, infoLabel);
+        addRow(row, infoLabel);
+        row++;
 
-
-        final JLabel debugPortLabel = new JLabel(translator.translate("debugPanel.debugPort.text") + ":");
-        final JTextField debugPortField = new JTextField();
-        debugPortField.setToolTipText(translator.translate("debugPanel.debugPort.description"));
-        debugPortField.setText(config.getProperty(OwsDefaultsProvider.REMOTE_DEBUG_PORT));
-        uiLock.update(OwsDefaultsProvider.REMOTE_DEBUG, debugPortField);
-        addRow(1, debugPortLabel, debugPortField);
-
-        final JCheckBox activateDebugCheckbox = new JCheckBox(translator.translate("debugPanel.activateDebug.text"));
+        activateDebugCheckbox = new JCheckBox(translator.translate("debugPanel.activateDebug.text"));
         activateDebugCheckbox.setToolTipText(translator.translate("debugPanel.activateDebug.description"));
         uiLock.update(OwsDefaultsProvider.REMOTE_DEBUG, activateDebugCheckbox);
-        activateDebugCheckbox.addChangeListener(e -> config.setProperty(OwsDefaultsProvider.REMOTE_DEBUG, Boolean.valueOf(activateDebugCheckbox.isSelected()).toString()));
         activateDebugCheckbox.setSelected(Boolean.parseBoolean(config.getProperty(OwsDefaultsProvider.REMOTE_DEBUG)));
-        addEditorRow(2, activateDebugCheckbox);
+        addRow(row, activateDebugCheckbox);
+        row++;
 
-        addRow(3, new JPanel());
+        startSuspendedCheckbox = new JCheckBox(translator.translate("debugPanel.startSuspended.text"));
+        startSuspendedCheckbox.setToolTipText(translator.translate("debugPanel.startSuspended.description"));
+        uiLock.update(OwsDefaultsProvider.START_SUSPENDED, startSuspendedCheckbox);
+        startSuspendedCheckbox.setSelected(Boolean.parseBoolean(config.getProperty(OwsDefaultsProvider.START_SUSPENDED)));
+        addRow(row, startSuspendedCheckbox);
+        row++;
 
-        final JTextArea messageLabel = new JTextArea();
+        anyPortCheckbox = new JCheckBox(translator.translate("debugPanel.randomPort.text"));
+        anyPortCheckbox.setToolTipText(translator.translate("debugPanel.randomPort.description"));
+        uiLock.update(OwsDefaultsProvider.RANDOM_DEBUG_PORT, anyPortCheckbox);
+        anyPortCheckbox.setSelected(Boolean.parseBoolean(config.getProperty(OwsDefaultsProvider.RANDOM_DEBUG_PORT)));
+        addRow(row, anyPortCheckbox);
+        row++;
+
+        debugPortLabel = new JLabel(translator.translate("debugPanel.specificPort.text") + ":");
+        debugPortField = new JTextField();
+        debugPortField.setToolTipText(translator.translate("debugPanel.specificPort.description"));
+        debugPortField.setText(config.getProperty(OwsDefaultsProvider.REMOTE_DEBUG_PORT));
+        uiLock.update(OwsDefaultsProvider.REMOTE_DEBUG, debugPortField);
+        addRow(row, debugPortLabel, debugPortField);
+        row++;
+
+        warningLabel = new JTextArea(translator.translate("debugPanel.oneInstanceWarning"));
+        warningLabel.setEditable(false);
+        warningLabel.setBackground(null);
+        warningLabel.setWrapStyleWord(true);
+        warningLabel.setLineWrap(true);
+        addRow(row, warningLabel);
+        final int warningLabelRow = row;
+        row++;
+
+        addRow(row, new JPanel());
+        final int panelRow = row;
+        row++;
+
+        messageLabel = new JTextArea();
         messageLabel.setEditable(false);
         messageLabel.setBackground(null);
         messageLabel.setWrapStyleWord(true);
         messageLabel.setLineWrap(true);
-        addRow(4, messageLabel);
+        addRow(row, messageLabel);
+        row++;
 
-        addFlexibleRow(5);
+        addFlexibleRow(warningLabelRow);
 
+        updateControlStatus();
+        activateDebugCheckbox.addChangeListener(
+                new ChangeListener() {
+                    @Override
+                    public void stateChanged(ChangeEvent e) {
+                        final boolean activated = activateDebugCheckbox.isSelected();
+                        config.setProperty(OwsDefaultsProvider.REMOTE_DEBUG, Boolean.valueOf(activated).toString());
+                        updateControlStatus();
+                    }
+                }
+        );
+        anyPortCheckbox.addChangeListener(
+                new ChangeListener() {
+                    @Override
+                    public void stateChanged(ChangeEvent e) {
+                        final boolean useAnyPort = anyPortCheckbox.isSelected();
+                        config.setProperty(OwsDefaultsProvider.RANDOM_DEBUG_PORT, Boolean.valueOf(useAnyPort).toString());
+                        updateControlStatus();
+                        updateMessageLabel();
+                    }
+                }
+        );
+        startSuspendedCheckbox.addChangeListener(
+                new ChangeListener() {
+                    @Override
+                    public void stateChanged(ChangeEvent e) {
+                        final boolean startSuspended = startSuspendedCheckbox.isSelected();
+                        config.setProperty(OwsDefaultsProvider.START_SUSPENDED, Boolean.valueOf(startSuspended).toString());
+                        updateMessageLabel();
+                    }
+                }
+        );
 
         final Consumer<String> onPortTextUpdate = s -> {
             try {
-                final int port = Integer.parseInt(debugPortField.getText());
+                final int port = getPortToBeUsed();
                 config.setProperty(OwsDefaultsProvider.REMOTE_DEBUG_PORT, port + "");
-                messageLabel.setText(translator.translate("debugPanel.description.success", Integer.toString(port)));
             } catch (final Exception ignore) {
-                final String lastValidValue = config.getProperty(OwsDefaultsProvider.REMOTE_DEBUG_PORT);
-                messageLabel.setText(translator.translate("debugPanel.description.fail", lastValidValue));
+                // invalid port
             }
+            updateMessageLabel();
         };
 
         debugPortField.getDocument().addDocumentListener(new DocumentListener() {

--- a/openwebstart/src/main/resources/i18n.properties
+++ b/openwebstart/src/main/resources/i18n.properties
@@ -108,12 +108,17 @@ loggingPanel.showLogWindowState.disable=Disable
 
 debugPanel.title=Remote Debugging
 debugPanel.info=The following option should only changed by developers that want to debug a JNLP based application by using remote debugging!
-debugPanel.debugPort.text=Port
-debugPanel.debugPort.description=The port for remote debugging
+debugPanel.specificPort.text=Specific port
+debugPanel.specificPort.description=The port for remote debugging
 debugPanel.activateDebug.text=Activate remote debugging
 debugPanel.activateDebug.description=By setting this flag the remote debugging will be activated
-debugPanel.description.success=Applications will be started with ''-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={0}''.\nOnly one application can be started in parallel while debugging is active!
-debugPanel.description.fail=Please define a valid port. At the moment the last valid port will be used and applications will be started with ''-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={0}''.\nOnly one application can be started in parallel while debugging is active!
+debugPanel.description.success=Applications will be started with:\n''{0}''.
+debugPanel.description.fail=Please define a valid port. At the moment the last valid port will be used and applications will be started with:\n''{0}''.
+debugPanel.randomPort.text=Any port (chosen randomly)
+debugPanel.randomPort.description=The port will be chosen randomly to make sure multiple debug instances can be run
+debugPanel.startSuspended.text=Start suspended
+debugPanel.startSuspended.description=Starts the JVM in suspended state so that you can easily debug the startup phase of the application
+debugPanel.oneInstanceWarning=Only one application can be started when specific port is used!
 
 proxyPanel.title=Proxy Settings
 proxyPanel.noProxy.text=No Proxy

--- a/openwebstart/src/main/resources/i18n_de.properties
+++ b/openwebstart/src/main/resources/i18n_de.properties
@@ -108,12 +108,17 @@ loggingPanel.showLogWindowState.disable=Deaktiviert
 
 debugPanel.title=Remote Debugging
 debugPanel.info=Die nachfolgenden Einstellungen sind f\u00FCr Entwickler gedacht welche eine JNLP Applikation debuggen m\u00F6chten.
-debugPanel.debugPort.text=Port
-debugPanel.debugPort.description=Der Port f\u00FCr den Remote Debugger
+debugPanel.specificPort.text=Spezifischer Port
+debugPanel.specificPort.description=Der Port f\u00FCr den Remote Debugger
 debugPanel.activateDebug.text=Remote Debugging
 debugPanel.activateDebug.description=Wenn diese Checkbox selektiert ist, ist das Remote Debugging aktiv
-debugPanel.description.success=Applikation wird mit ''-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={0}'' gestartet.\nHinweis: es k\u00F6nnen nicht mehrere Applikation gleichzeitig mit Remote Debugging gestartet werden.
-debugPanel.description.fail=Ung\u00FCltiger Port: Bitte geben Sie einen g\u00FCltigen Port ein.\nApplikation wird mit ''-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={0}'' gestartet.\nHinweis: es k\u00F6nnen nicht mehrere Applikation gleichzeitig mit Remote Debugging gestartet werden.
+debugPanel.description.success=Applikation wird mit ''{0}'' gestartet.
+debugPanel.description.fail=Ung\u00FCltiger Port: Bitte geben Sie einen g\u00FCltigen Port ein.\nApplikation wird mit ''{0}'' gestartet.
+debugPanel.randomPort.text=Any port (chosen randomly)
+debugPanel.randomPort.description=The port will be chosen randomly to make sure multiple debug instances can be run
+debugPanel.startSuspended.text=Start suspended
+debugPanel.startSuspended.description=Starts the JVM in suspended state so that you can easily debug the startup phase of the application
+debugPanel.oneInstanceWarning=Only one application can be started when specific port is used!
 
 #proxyPanel.title
 proxyPanel.noProxy.text=Kein Proxy

--- a/openwebstart/src/main/resources/i18n_fr.properties
+++ b/openwebstart/src/main/resources/i18n_fr.properties
@@ -108,12 +108,17 @@ loggingPanel.showLogWindowState.disable=Désactiver
 
 debugPanel.title=Débogage à distance
 debugPanel.info=L''option suivante ne devrait être modifiée que par les développeurs qui veulent déboguer une application basée sur JNLP en utilisant le débogage à distance !
-debugPanel.debugPort.text=Port
-debugPanel.debugPort.description=Le port pour le débogage à distance
+debugPanel.specificPort.text=Port spécifique
+debugPanel.specificPort.description=Le port pour le débogage à distance
 debugPanel.activateDebug.text=Activer le débogage à distance
 debugPanel.activateDebug.description=En activant ce flag, le débogage à distance sera activé
-debugPanel.description.success=Les applications seront lancées avec ''-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={0}''.\nUne seule application peut être lancée en parallèle pendant que le débogage est actif !
-debugPanel.description.fail=Veuillez définir un port valide. Pour le moment, le dernier port valide sera utilisé et les applications seront lancées avec ''-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={0}''.\nUne seule application peut être lancée en parallèle pendant que le débogage est actif !
+debugPanel.description.success=Les applications seront lancées avec:\n''{0}''.
+debugPanel.description.fail=Veuillez définir un port valide. Pour le moment, le dernier port valide sera utilisé et les applications seront lancées avec:\n''{0}''.
+debugPanel.randomPort.text=N'importe quel port (choisi de manière aléatoire)
+debugPanel.randomPort.description=Le port sera choisi de manière aléatoire pour s'assurer que plusieurs instances de débogage peuvent être exécutées
+debugPanel.startSuspended.text=Démarrer suspendu
+debugPanel.startSuspended.description=Démarre la JVM en état suspendu pour que vous puissiez facilement déboguer la phase de démarrage de l'application
+debugPanel.oneInstanceWarning=Une seule application peut être lancée si un port spécifique est utilisé!
 
 proxyPanel.title=Paramètres du proxy
 proxyPanel.noProxy.text=Pas de proxy


### PR DESCRIPTION
I implemented the UI dialog for the Remote Debugging. #248 

The only thing I was unable to complete is the German translation. I put the strings in English to make sure the lack of translation is visible. I must confess that the unicode escapes are something that I don't understand in case of German translation since the French one doesn't do that for the letters with accents.

The French translation is completed; it needs someone with French experience to make sure it is acceptable for French natives also; for me it is.