### PR TITLE
Desktop integration for macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 **/dependency-reduced-pom.xml
 
 jdk.zip
+.project
+**/.settings
+.classpath

--- a/openwebstart/src/main/java/com/openwebstart/os/ScriptFactory.java
+++ b/openwebstart/src/main/java/com/openwebstart/os/ScriptFactory.java
@@ -14,6 +14,10 @@ public class ScriptFactory
     private final static String SCRIPT_START = "#!/bin/sh";
 
     private static final String JAVA_WS_NAME = "javaws";
+    
+    private static final String HTTP		 = "http";
+    private static final String HTTPS		 = "https";
+    private static final String JNLP		 = "jnlp";
 
     public static String createStartScript(final JNLPFile jnlpFile) {
         if(OperationSystem.getLocalSystem() == OperationSystem.MAC64) {
@@ -43,8 +47,8 @@ public class ScriptFactory
 		final URL srcUrl = jnlpFile.getSourceLocation();
 		final String schema = srcUrl.getProtocol();
 		final String url;
-		if ("http".equalsIgnoreCase(schema) || "https".equalsIgnoreCase(schema)) {
-			url = "jnlp" + srcUrl.toString().substring(4);
+		if (HTTP.equalsIgnoreCase(schema) || HTTPS.equalsIgnoreCase(schema)) {
+			url = JNLP + srcUrl.toString().substring(4);
 		} else {
 			url = srcUrl.toString();
 		}

--- a/openwebstart/src/main/java/com/openwebstart/os/ScriptFactory.java
+++ b/openwebstart/src/main/java/com/openwebstart/os/ScriptFactory.java
@@ -39,21 +39,17 @@ public class ScriptFactory
         return SCRIPT_START + System.lineSeparator() + "open -a " + executable + " " + jnlpLocation;
     }
 
-    public static String createSimpleStartScriptForMac(final JNLPFile jnlpFile) 
-    {
-    	final URL 		srcUrl = jnlpFile.getSourceLocation();
-    	final String	schema = srcUrl.getProtocol();
-    	final String	url;
-   		if ( "http".equalsIgnoreCase(schema) || "https".equalsIgnoreCase(schema) )
-   		{
-   			url = "jnlp" + srcUrl.toString().substring( 4 );
-    	}
-   		else
-   		{
-   			url = srcUrl.toString();
-   		}
-        return SCRIPT_START + System.lineSeparator() + "open \"" + url + "\"";
-    }
+	public static String createSimpleStartScriptForMac(final JNLPFile jnlpFile) {
+		final URL srcUrl = jnlpFile.getSourceLocation();
+		final String schema = srcUrl.getProtocol();
+		final String url;
+		if ("http".equalsIgnoreCase(schema) || "https".equalsIgnoreCase(schema)) {
+			url = "jnlp" + srcUrl.toString().substring(4);
+		} else {
+			url = srcUrl.toString();
+		}
+		return SCRIPT_START + System.lineSeparator() + "open \"" + url + "\"";
+	}
 
     public static Process createStartProcess(final JNLPFile jnlpFile) throws IOException {
         final String executable = "\"" + Install4JUtils.installationDirectory()

--- a/openwebstart/src/main/java/com/openwebstart/os/ScriptFactory.java
+++ b/openwebstart/src/main/java/com/openwebstart/os/ScriptFactory.java
@@ -30,19 +30,6 @@ public class ScriptFactory
         return executable + " " + jnlpLocation;
     }
 
-    public static String createStartScriptForMac(final JNLPFile jnlpFile) {
-        final String executable = "\"" + Install4JUtils.installationDirectory()
-                .map(d -> d + "/" + "OpenWebStart javaws.app" + "\"")
-                .orElseThrow(() -> new IllegalStateException("Can not define executable"));
-
-        //TODO: URL is not working on mac. Maybe we can add a new param to OWS that can be used to pass
-        // the jnlp url (mac open command supports --args)
-        // This one is not working: open -a "/Applications/OpenWebStart/OpenWebStart javaws.app" --args -jnlp "file:/Users/hendrikebbers/Desktop/AccessibleScrollDemo.jnlpx"
-        final String jnlpLocation = "\"" + jnlpFile.getFileLocation() + "\"";
-
-        return SCRIPT_START + System.lineSeparator() + "open -a " + executable + " " + jnlpLocation;
-    }
-
 	public static String createSimpleStartScriptForMac(final JNLPFile jnlpFile) {
 		final URL srcUrl = jnlpFile.getSourceLocation();
 		final String schema = srcUrl.getProtocol();

--- a/openwebstart/src/main/java/com/openwebstart/os/ScriptFactory.java
+++ b/openwebstart/src/main/java/com/openwebstart/os/ScriptFactory.java
@@ -1,25 +1,23 @@
 package com.openwebstart.os;
 
-import com.openwebstart.install4j.Install4JUtils;
-import com.openwebstart.jvm.os.OperationSystem;
-import net.adoptopenjdk.icedteaweb.logging.Logger;
-import net.adoptopenjdk.icedteaweb.logging.LoggerFactory;
-import net.sourceforge.jnlp.JNLPFile;
-
 import java.io.IOException;
+import java.net.URL;
 import java.util.Optional;
 
-public class ScriptFactory {
+import com.openwebstart.install4j.Install4JUtils;
+import com.openwebstart.jvm.os.OperationSystem;
 
-    private final static Logger LOG = LoggerFactory.getLogger(ScriptFactory.class);
+import net.sourceforge.jnlp.JNLPFile;
 
+public class ScriptFactory 
+{
     private final static String SCRIPT_START = "#!/bin/sh";
 
     private static final String JAVA_WS_NAME = "javaws";
 
     public static String createStartScript(final JNLPFile jnlpFile) {
         if(OperationSystem.getLocalSystem() == OperationSystem.MAC64) {
-            return createStartScriptForMac(jnlpFile);
+            return createSimpleStartScriptForMac(jnlpFile);
         }
         final String executable = Install4JUtils.installationDirectory()
                 .map(d -> d + "/" + JAVA_WS_NAME)
@@ -39,6 +37,22 @@ public class ScriptFactory {
         final String jnlpLocation = "\"" + jnlpFile.getFileLocation() + "\"";
 
         return SCRIPT_START + System.lineSeparator() + "open -a " + executable + " " + jnlpLocation;
+    }
+
+    public static String createSimpleStartScriptForMac(final JNLPFile jnlpFile) 
+    {
+    	final URL 		srcUrl = jnlpFile.getSourceLocation();
+    	final String	schema = srcUrl.getProtocol();
+    	final String	url;
+   		if ( "http".equalsIgnoreCase(schema) || "https".equalsIgnoreCase(schema) )
+   		{
+   			url = "jnlp" + srcUrl.toString().substring( 4 );
+    	}
+   		else
+   		{
+   			url = srcUrl.toString();
+   		}
+        return SCRIPT_START + System.lineSeparator() + "open \"" + url + "\"";
     }
 
     public static Process createStartProcess(final JNLPFile jnlpFile) throws IOException {

--- a/openwebstart/src/main/java/com/openwebstart/os/mac/AppFactory.java
+++ b/openwebstart/src/main/java/com/openwebstart/os/mac/AppFactory.java
@@ -51,6 +51,12 @@ public class AppFactory {
     private final static String ICON_FILE_NAME = "icons";
 
     private final static String ICON_FILE_EXTENSION = ".icns";
+    
+    private final static String USER_APPLICATIONS_FOLDER = "Applications";
+
+    private final static String USER_APPLICATIONS_CACHE_FOLDER = "applications";
+    
+    private final static String USER_DESKTOP = "Desktop";
 
     public static boolean exists(final String name) {
         Assert.requireNonBlank(name, "name");
@@ -148,7 +154,7 @@ public class AppFactory {
     private final static Path ensureUserApplicationFolder()
     {
     	final String userHome = JavaSystemProperties.getUserHome();
-    	final File appFolder = new File( new File(userHome), "Applications");
+    	final File appFolder = new File( new File(userHome), USER_APPLICATIONS_FOLDER);
     	if ( !appFolder.exists() )
     	{
     		appFolder.mkdir();
@@ -157,7 +163,7 @@ public class AppFactory {
     }
     
 	private final static Path ensureUserApplicationCacheFolder() {
-		final Path appcache = Paths.get(FilesystemConfiguration.getCacheHome(), "applications");
+		final Path appcache = Paths.get(FilesystemConfiguration.getCacheHome(), USER_APPLICATIONS_CACHE_FOLDER);
 		if (!Files.isDirectory(appcache)) {
 			try {
 				Files.createDirectories(appcache);
@@ -170,7 +176,7 @@ public class AppFactory {
     
     final static Path getApplicationRootInCache( final String name )
     {
-    	return Paths.get(FilesystemConfiguration.getCacheHome(), "applications", name + APP_EXTENSION );
+    	return Paths.get(FilesystemConfiguration.getCacheHome(), USER_APPLICATIONS_CACHE_FOLDER, name + APP_EXTENSION );
     }
     
 	public final static boolean desktopLinkExists(final String appname) {
@@ -206,6 +212,6 @@ public class AppFactory {
 
     private final static Path getDesktopLink(final String appname)
     {
-    	return Paths.get(JavaSystemProperties.getUserHome(), "Desktop", appname + APP_EXTENSION );
+    	return Paths.get(JavaSystemProperties.getUserHome(), USER_DESKTOP, appname + APP_EXTENSION );
     }
 }

--- a/openwebstart/src/main/java/com/openwebstart/os/mac/AppFactory.java
+++ b/openwebstart/src/main/java/com/openwebstart/os/mac/AppFactory.java
@@ -189,7 +189,7 @@ public class AppFactory {
 					final Path linkRealPath = link.toRealPath();
 					return cache.toRealPath().equals(linkRealPath);
 				} catch (final Exception e) {
-					/* ignore this error */
+					LOG.debug("Coluld not verify desktop link [" + link + "]", e);
 				}
 			}
 		}

--- a/openwebstart/src/main/java/com/openwebstart/os/mac/MacEntryFactory.java
+++ b/openwebstart/src/main/java/com/openwebstart/os/mac/MacEntryFactory.java
@@ -45,9 +45,10 @@ public class MacEntryFactory implements MenuAndDesktopEntriesFactory {
     }
 
     @Override
-    public void updateMenuEntry(final JNLPFile file) {
-        throw new RuntimeException("not implemented yet!");
-        // not implemented
+    public void updateMenuEntry(final JNLPFile file)
+    	throws Exception
+    {
+    	this.createMenuEntry(file);
     }
 
     @Override

--- a/openwebstart/src/main/java/com/openwebstart/os/mac/MacEntryFactory.java
+++ b/openwebstart/src/main/java/com/openwebstart/os/mac/MacEntryFactory.java
@@ -37,16 +37,14 @@ public class MacEntryFactory implements MenuAndDesktopEntriesFactory {
     	createDesktopEntry(file);    
     }
 
-    @Override
-    public void createDesktopEntry(final JNLPFile file) 
-    	throws Exception
-    {
-        final String name = file.getShortcutName();
-        final String script = ScriptFactory.createStartScript(file);
-        final String[] icons = getIcons(file);
-    	
-        AppFactory.createDesktopLink(name, script, icons);
-    }
+	@Override
+	public void createDesktopEntry(final JNLPFile file) throws Exception {
+		final String name = file.getShortcutName();
+		final String script = ScriptFactory.createStartScript(file);
+		final String[] icons = getIcons(file);
+
+		AppFactory.createDesktopLink(name, script, icons);
+	}
 
     @Override
     public boolean existsDesktopEntry(final JNLPFile file) 

--- a/openwebstart/src/main/java/com/openwebstart/os/mac/MacEntryFactory.java
+++ b/openwebstart/src/main/java/com/openwebstart/os/mac/MacEntryFactory.java
@@ -25,23 +25,33 @@ import java.util.stream.Collectors;
 public class MacEntryFactory implements MenuAndDesktopEntriesFactory {
 
     @Override
-    public boolean supportsDesktopEntry() {
-        return false;
+    public boolean supportsDesktopEntry() 
+    {
+        return true;
     }
 
     @Override
-    public void updateDesktopEntry(final JNLPFile file) {
-        throw new RuntimeException("Operation not supported");
+    public void updateDesktopEntry(final JNLPFile file)
+    	throws Exception 
+    {
+    	createDesktopEntry(file);    
     }
 
     @Override
-    public void createDesktopEntry(final JNLPFile file) {
-        throw new RuntimeException("Operation not supported");
+    public void createDesktopEntry(final JNLPFile file) 
+    	throws Exception
+    {
+        final String name = file.getShortcutName();
+        final String script = ScriptFactory.createStartScript(file);
+        final String[] icons = getIcons(file);
+    	
+        AppFactory.createDesktopLink(name, script, icons);
     }
 
     @Override
-    public boolean existsDesktopEntry(final JNLPFile file) {
-        return false;
+    public boolean existsDesktopEntry(final JNLPFile file) 
+    {
+        return AppFactory.desktopLinkExists(file.getShortcutName());
     }
 
     @Override

--- a/openwebstart/src/main/java/com/openwebstart/os/mac/MacEntryFactory.java
+++ b/openwebstart/src/main/java/com/openwebstart/os/mac/MacEntryFactory.java
@@ -27,7 +27,7 @@ public class MacEntryFactory implements MenuAndDesktopEntriesFactory {
     @Override
     public boolean supportsDesktopEntry() 
     {
-        return true;
+        return false;
     }
 
     @Override

--- a/openwebstart/src/main/java/com/openwebstart/os/mac/MacEntryFactory.java
+++ b/openwebstart/src/main/java/com/openwebstart/os/mac/MacEntryFactory.java
@@ -25,15 +25,12 @@ import java.util.stream.Collectors;
 public class MacEntryFactory implements MenuAndDesktopEntriesFactory {
 
     @Override
-    public boolean supportsDesktopEntry() 
-    {
+    public boolean supportsDesktopEntry() {
         return false;
     }
 
     @Override
-    public void updateDesktopEntry(final JNLPFile file)
-    	throws Exception 
-    {
+    public void updateDesktopEntry(final JNLPFile file)	throws Exception {
     	createDesktopEntry(file);    
     }
 
@@ -47,15 +44,12 @@ public class MacEntryFactory implements MenuAndDesktopEntriesFactory {
 	}
 
     @Override
-    public boolean existsDesktopEntry(final JNLPFile file) 
-    {
+    public boolean existsDesktopEntry(final JNLPFile file) {
         return AppFactory.desktopLinkExists(file.getShortcutName());
     }
 
     @Override
-    public void updateMenuEntry(final JNLPFile file)
-    	throws Exception
-    {
+    public void updateMenuEntry(final JNLPFile file) throws Exception {
     	this.createMenuEntry(file);
     }
 

--- a/openwebstart/src/test/java/com/openwebstart/os/mac/AppFactoryTest.java
+++ b/openwebstart/src/test/java/com/openwebstart/os/mac/AppFactoryTest.java
@@ -1,5 +1,7 @@
 package com.openwebstart.os.mac;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
@@ -38,9 +40,9 @@ public final class AppFactoryTest extends Object {
 
 		try {
 			System.setProperty(JavaSystemPropertiesConstants.USER_HOME, userHome);
-			assert userHome.equals(JavaSystemProperties.getUserHome());
+			assertTrue(userHome.equals(JavaSystemProperties.getUserHome()));
 			updateCacheHome(userCache);
-			assert userCache.equals(FilesystemConfiguration.getCacheHome());
+			assertTrue(userCache.equals(FilesystemConfiguration.getCacheHome()));
 
 			final String appName = "MyFirstApp";
 
@@ -48,16 +50,16 @@ public final class AppFactoryTest extends Object {
 
 			AppFactory.createApp(appName, script, IcnsFactorySample.class.getResource("icon.png").getFile());
 
-			assert Files.exists(Paths.get(userHome));
-			assert Files.exists(Paths.get(userCache));
-			assert Files.exists(Paths.get(userCache, "applications"));
-			assert Files.exists(Paths.get(userCache, "applications", appNameWithSuffix));
+			assertTrue(Files.exists(Paths.get(userHome)));
+			assertTrue(Files.exists(Paths.get(userCache)));
+			assertTrue(Files.exists(Paths.get(userCache, "applications")));
+			assertTrue(Files.exists(Paths.get(userCache, "applications", appNameWithSuffix)));
 
-			assert Files.exists(Paths.get(userHome, "Applications"));
+			assertTrue(Files.exists(Paths.get(userHome, "Applications")));
 			final Path link = Paths.get(userHome, "Applications", appNameWithSuffix);
-			assert Files.exists(link);
-			assert Files.isSymbolicLink(link);
-			assert link.toRealPath().equals(Paths.get(userCache, "applications", appNameWithSuffix).toRealPath());
+			assertTrue(Files.exists(link));
+			assertTrue(Files.isSymbolicLink(link));
+			assertTrue(link.toRealPath().equals(Paths.get(userCache, "applications", appNameWithSuffix).toRealPath()));
 
 			// do it again
 			AppFactory.createApp(appName, script, IcnsFactorySample.class.getResource("icon.png").getFile());
@@ -73,38 +75,38 @@ public final class AppFactoryTest extends Object {
 		}
 
 		FileUtils.recursiveDelete(new File(userHome), new File("/tmp"));
-		assert new File(userHome).exists() == false;
+		assertTrue(new File(userHome).exists() == false);
 
 		final String appName = "MyFirstApp";
 		final String appNameWithSuffix = appName + AppFactory.APP_EXTENSION;
 
 		try {
 			System.setProperty(JavaSystemPropertiesConstants.USER_HOME, userHome);
-			assert userHome.equals(JavaSystemProperties.getUserHome());
+			assertTrue(userHome.equals(JavaSystemProperties.getUserHome()));
 			updateCacheHome(userCache);
-			assert userCache.equals(FilesystemConfiguration.getCacheHome());
+			assertTrue(userCache.equals(FilesystemConfiguration.getCacheHome()));
 
-			assert AppFactory.desktopLinkExists(appName) == false;
+			assertTrue(AppFactory.desktopLinkExists(appName) == false);
 
 			final Path desktop = Paths.get(JavaSystemProperties.getUserHome(), "Desktop");
 			Files.createDirectories(desktop);
-			assert Files.isDirectory(desktop);
+			assertTrue(Files.isDirectory(desktop));
 
 			final Path link = desktop.resolve(appNameWithSuffix);
 
 			{ // regular file
-				assert Files.exists(link) == false;
+				assertTrue(Files.exists(link) == false);
 				Files.createFile(link);
-				assert Files.exists(link) == true;
-				assert AppFactory.desktopLinkExists(appName) == false;
+				assertTrue(Files.exists(link) == true);
+				assertTrue(AppFactory.desktopLinkExists(appName) == false);
 				Files.delete(link);
 			}
 
 			{ // directory
-				assert Files.exists(link) == false;
+				assertTrue(Files.exists(link) == false);
 				Files.createDirectories(link);
-				assert Files.isDirectory(link) == true;
-				assert AppFactory.desktopLinkExists(appName) == false;
+				assertTrue(Files.isDirectory(link) == true);
+				assertTrue(AppFactory.desktopLinkExists(appName) == false);
 				Files.delete(link);
 			}
 
@@ -112,18 +114,18 @@ public final class AppFactoryTest extends Object {
 					IcnsFactorySample.class.getResource("icon.png").getFile()).toPath();
 
 			{ // wrong link
-				assert Files.exists(link) == false;
+				assertTrue(Files.exists(link) == false);
 				Files.createSymbolicLink(link, appRoot.resolve(AppFactory.CONTENTS_FOLDER_NAME));
-				assert Files.isSymbolicLink(link) == true;
-				assert AppFactory.desktopLinkExists(appName) == false;
+				assertTrue(Files.isSymbolicLink(link) == true);
+				assertTrue(AppFactory.desktopLinkExists(appName) == false);
 				Files.delete(link);
 			}
 
 			{ // wrong link
-				assert Files.exists(link) == false;
+				assertTrue(Files.exists(link) == false);
 				Files.createSymbolicLink(link, appRoot);
-				assert Files.isSymbolicLink(link) == true;
-				assert AppFactory.desktopLinkExists(appName) == true;
+				assertTrue(Files.isSymbolicLink(link) == true);
+				assertTrue(AppFactory.desktopLinkExists(appName) == true);
 				Files.delete(link);
 			}
 		} finally {
@@ -138,27 +140,27 @@ public final class AppFactoryTest extends Object {
 		}
 
 		FileUtils.recursiveDelete(new File(userHome), new File("/tmp"));
-		assert new File(userHome).exists() == false;
+		assertTrue(new File(userHome).exists() == false);
 
 		final String appName = "MyFirstApp";
 		final String appNameWithSuffix = appName + AppFactory.APP_EXTENSION;
 
 		try {
 			System.setProperty(JavaSystemPropertiesConstants.USER_HOME, userHome);
-			assert userHome.equals(JavaSystemProperties.getUserHome());
+			assertTrue(userHome.equals(JavaSystemProperties.getUserHome()));
 			updateCacheHome(userCache);
-			assert userCache.equals(FilesystemConfiguration.getCacheHome());
+			assertTrue(userCache.equals(FilesystemConfiguration.getCacheHome()));
 
 			final Path desktop = Paths.get(JavaSystemProperties.getUserHome(), "Desktop");
 			Files.createDirectories(desktop);
-			assert Files.isDirectory(desktop);
+			assertTrue(Files.isDirectory(desktop));
 
 			final Path link = desktop.resolve(appNameWithSuffix);
-			assert Files.exists(link) == false;
+			assertTrue(Files.exists(link) == false);
 
 			AppFactory.createDesktopLink(appName, script, IcnsFactorySample.class.getResource("icon.png").getFile());
 
-			assert Files.isSymbolicLink(link);
+			assertTrue(Files.isSymbolicLink(link));
 		} finally {
 			restoreOrigins();
 		}

--- a/openwebstart/src/test/java/com/openwebstart/os/mac/AppFactoryTest.java
+++ b/openwebstart/src/test/java/com/openwebstart/os/mac/AppFactoryTest.java
@@ -10,8 +10,9 @@ import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
-import com.openwebstart.jvm.os.OperationSystem;
 import com.openwebstart.os.mac.icns.IcnsFactorySample;
 
 import net.adoptopenjdk.icedteaweb.JavaSystemProperties;
@@ -30,10 +31,8 @@ public final class AppFactoryTest extends Object {
 	private final static String userCache = "/tmp/dummy/.cache";
 
 	@Test
+	@EnabledOnOs(OS.MAC)
 	public void testCreateApp() throws Exception {
-		if (!OperationSystem.getLocalSystem().equals(OperationSystem.MAC64)) {
-			return;
-		}
 
 		FileUtils.recursiveDelete(new File(userHome), new File("/tmp"));
 		assertTrue(new File(userHome).exists() == false);
@@ -69,11 +68,8 @@ public final class AppFactoryTest extends Object {
 	}
 
 	@Test
+	@EnabledOnOs(OS.MAC)
 	public void testDesktopLinkExists() throws Exception {
-		if (!OperationSystem.getLocalSystem().equals(OperationSystem.MAC64)) {
-			return;
-		}
-
 		FileUtils.recursiveDelete(new File(userHome), new File("/tmp"));
 		assertTrue(new File(userHome).exists() == false);
 
@@ -134,11 +130,8 @@ public final class AppFactoryTest extends Object {
 	}
 
 	@Test
+	@EnabledOnOs(OS.MAC)
 	public void testCreateDesktopLink() throws Exception {
-		if (!OperationSystem.getLocalSystem().equals(OperationSystem.MAC64)) {
-			return;
-		}
-
 		FileUtils.recursiveDelete(new File(userHome), new File("/tmp"));
 		assertTrue(new File(userHome).exists() == false);
 

--- a/openwebstart/src/test/java/com/openwebstart/os/mac/AppFactoryTest.java
+++ b/openwebstart/src/test/java/com/openwebstart/os/mac/AppFactoryTest.java
@@ -1,0 +1,95 @@
+package com.openwebstart.os.mac;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import com.openwebstart.jvm.os.OperationSystem;
+import com.openwebstart.os.mac.icns.IcnsFactorySample;
+
+import net.adoptopenjdk.icedteaweb.JavaSystemProperties;
+import net.adoptopenjdk.icedteaweb.JavaSystemPropertiesConstants;
+import net.adoptopenjdk.icedteaweb.config.FilesystemConfiguration;
+import net.adoptopenjdk.icedteaweb.io.FileUtils;
+
+public final class AppFactoryTest
+	extends Object
+{
+    private final static String SCRIPT_START = "#!/bin/sh";
+    private final static String script = SCRIPT_START + System.lineSeparator() + "open -a Calculator";
+    
+	final static String originUserHome	= JavaSystemProperties.getUserHome();
+	final static String originCacheHome	= FilesystemConfiguration.getCacheHome();
+
+	private final static String userHome = "/tmp/dummy";
+	private final static String userCache = "/tmp/dummy/.cache";
+	
+	
+	@Test
+	public void testCreateApp() 
+		throws Exception
+	{
+		if ( !OperationSystem.getLocalSystem().equals(OperationSystem.MAC64) )
+		{
+			return;
+		}
+
+		FileUtils.recursiveDelete(new File(userHome), new File("/tmp"));
+		assert new File(userHome).exists()==false;
+		
+		try
+		{
+	    	System.setProperty(JavaSystemPropertiesConstants.USER_HOME, userHome);
+	    	assert userHome.equals(JavaSystemProperties.getUserHome());
+	    	updateCacheHome(userCache);
+	    	assert userCache.equals(FilesystemConfiguration.getCacheHome());
+	    	
+	    	final String appName = "MyFirstApp";
+	    	
+	    	final String appNameWithSuffix = appName + AppFactory.APP_EXTENSION;
+	    	
+	        AppFactory.createApp( appName, script, IcnsFactorySample.class.getResource("icon.png").getFile());
+	        
+	        assert Files.exists(Paths.get(userHome));
+	        assert Files.exists(Paths.get(userCache));
+	        assert Files.exists(Paths.get(userCache, "applications"));
+	        assert Files.exists(Paths.get(userCache, "applications", appNameWithSuffix ));
+
+	        assert Files.exists(Paths.get(userHome, "Applications"));
+	        final Path link = Paths.get(userHome, "Applications", appNameWithSuffix);
+	        assert Files.exists(link);
+	        assert Files.isSymbolicLink(link);
+	        assert link.toRealPath().equals(Paths.get(userCache, "applications", appNameWithSuffix).toRealPath());
+
+	        // do it again
+	        AppFactory.createApp( appName, script, IcnsFactorySample.class.getResource("icon.png").getFile());
+		}
+		finally
+		{
+			restoreOrigins();
+		}
+	}
+
+	private final static void restoreOrigins()
+		throws Exception
+	{
+    	System.setProperty(JavaSystemPropertiesConstants.USER_HOME, originUserHome);
+    	assert originUserHome.equals(JavaSystemProperties.getUserHome());
+    	updateCacheHome(originCacheHome);
+    	assert originCacheHome.equals(FilesystemConfiguration.getCacheHome());
+	}
+	
+	@SuppressWarnings("unchecked")
+	private static void updateCacheHome( final String val ) 
+		throws ReflectiveOperationException 
+	{
+		final Field field = FilesystemConfiguration.class.getDeclaredField("cacheHome");
+		field.setAccessible(true);
+		((AtomicReference<String>) field.get(null)).set(val);
+	}
+}

--- a/openwebstart/src/test/java/com/openwebstart/os/mac/AppFactoryTest.java
+++ b/openwebstart/src/test/java/com/openwebstart/os/mac/AppFactoryTest.java
@@ -41,7 +41,7 @@ public final class AppFactoryTest extends Object {
 	}
 
 	@AfterAll
-	void restoreOrigins() throws Exception {
+	static void restoreOrigins() throws Exception {
 		System.setProperty(JavaSystemPropertiesConstants.USER_HOME, originUserHome);
 		assert originUserHome.equals(JavaSystemProperties.getUserHome());
 		updateCacheHome(originCacheHome);

--- a/openwebstart/src/test/java/com/openwebstart/os/mac/AppFactoryTest.java
+++ b/openwebstart/src/test/java/com/openwebstart/os/mac/AppFactoryTest.java
@@ -46,6 +46,8 @@ public final class AppFactoryTest extends Object {
 		assert originUserHome.equals(JavaSystemProperties.getUserHome());
 		updateCacheHome(originCacheHome);
 		assert originCacheHome.equals(FilesystemConfiguration.getCacheHome());
+		
+		FileUtils.recursiveDelete(new File(userHome), new File("/tmp"));
 	}
 	
 	@Test

--- a/openwebstart/src/test/java/com/openwebstart/os/mac/AppFactoryTest.java
+++ b/openwebstart/src/test/java/com/openwebstart/os/mac/AppFactoryTest.java
@@ -17,189 +17,162 @@ import net.adoptopenjdk.icedteaweb.JavaSystemPropertiesConstants;
 import net.adoptopenjdk.icedteaweb.config.FilesystemConfiguration;
 import net.adoptopenjdk.icedteaweb.io.FileUtils;
 
-public final class AppFactoryTest
-	extends Object
-{
-    private final static String SCRIPT_START = "#!/bin/sh";
-    private final static String script = SCRIPT_START + System.lineSeparator() + "open -a Calculator";
-    
-	final static String originUserHome	= JavaSystemProperties.getUserHome();
-	final static String originCacheHome	= FilesystemConfiguration.getCacheHome();
+public final class AppFactoryTest extends Object {
+	private final static String SCRIPT_START = "#!/bin/sh";
+	private final static String script = SCRIPT_START + System.lineSeparator() + "open -a Calculator";
+
+	final static String originUserHome = JavaSystemProperties.getUserHome();
+	final static String originCacheHome = FilesystemConfiguration.getCacheHome();
 
 	private final static String userHome = "/tmp/dummy";
 	private final static String userCache = "/tmp/dummy/.cache";
-	
-	
+
 	@Test
-	public void testCreateApp() 
-		throws Exception
-	{
-		if ( !OperationSystem.getLocalSystem().equals(OperationSystem.MAC64) )
-		{
+	public void testCreateApp() throws Exception {
+		if (!OperationSystem.getLocalSystem().equals(OperationSystem.MAC64)) {
 			return;
 		}
 
 		FileUtils.recursiveDelete(new File(userHome), new File("/tmp"));
-		assert new File(userHome).exists()==false;
-		
-		try
-		{
-	    	System.setProperty(JavaSystemPropertiesConstants.USER_HOME, userHome);
-	    	assert userHome.equals(JavaSystemProperties.getUserHome());
-	    	updateCacheHome(userCache);
-	    	assert userCache.equals(FilesystemConfiguration.getCacheHome());
-	    	
-	    	final String appName = "MyFirstApp";
-	    	
-	    	final String appNameWithSuffix = appName + AppFactory.APP_EXTENSION;
-	    	
-	        AppFactory.createApp( appName, script, IcnsFactorySample.class.getResource("icon.png").getFile());
-	        
-	        assert Files.exists(Paths.get(userHome));
-	        assert Files.exists(Paths.get(userCache));
-	        assert Files.exists(Paths.get(userCache, "applications"));
-	        assert Files.exists(Paths.get(userCache, "applications", appNameWithSuffix ));
+		assert new File(userHome).exists() == false;
 
-	        assert Files.exists(Paths.get(userHome, "Applications"));
-	        final Path link = Paths.get(userHome, "Applications", appNameWithSuffix);
-	        assert Files.exists(link);
-	        assert Files.isSymbolicLink(link);
-	        assert link.toRealPath().equals(Paths.get(userCache, "applications", appNameWithSuffix).toRealPath());
+		try {
+			System.setProperty(JavaSystemPropertiesConstants.USER_HOME, userHome);
+			assert userHome.equals(JavaSystemProperties.getUserHome());
+			updateCacheHome(userCache);
+			assert userCache.equals(FilesystemConfiguration.getCacheHome());
 
-	        // do it again
-	        AppFactory.createApp( appName, script, IcnsFactorySample.class.getResource("icon.png").getFile());
-		}
-		finally
-		{
+			final String appName = "MyFirstApp";
+
+			final String appNameWithSuffix = appName + AppFactory.APP_EXTENSION;
+
+			AppFactory.createApp(appName, script, IcnsFactorySample.class.getResource("icon.png").getFile());
+
+			assert Files.exists(Paths.get(userHome));
+			assert Files.exists(Paths.get(userCache));
+			assert Files.exists(Paths.get(userCache, "applications"));
+			assert Files.exists(Paths.get(userCache, "applications", appNameWithSuffix));
+
+			assert Files.exists(Paths.get(userHome, "Applications"));
+			final Path link = Paths.get(userHome, "Applications", appNameWithSuffix);
+			assert Files.exists(link);
+			assert Files.isSymbolicLink(link);
+			assert link.toRealPath().equals(Paths.get(userCache, "applications", appNameWithSuffix).toRealPath());
+
+			// do it again
+			AppFactory.createApp(appName, script, IcnsFactorySample.class.getResource("icon.png").getFile());
+		} finally {
 			restoreOrigins();
 		}
 	}
 
 	@Test
-	public void testDesktopLinkExists() 
-		throws Exception
-	{
-		if ( !OperationSystem.getLocalSystem().equals(OperationSystem.MAC64) )
-		{
+	public void testDesktopLinkExists() throws Exception {
+		if (!OperationSystem.getLocalSystem().equals(OperationSystem.MAC64)) {
 			return;
 		}
 
 		FileUtils.recursiveDelete(new File(userHome), new File("/tmp"));
-		assert new File(userHome).exists()==false;
+		assert new File(userHome).exists() == false;
 
 		final String appName = "MyFirstApp";
 		final String appNameWithSuffix = appName + AppFactory.APP_EXTENSION;
-		
-		try
-		{
-	    	System.setProperty(JavaSystemPropertiesConstants.USER_HOME, userHome);
-	    	assert userHome.equals(JavaSystemProperties.getUserHome());
-	    	updateCacheHome(userCache);
-	    	assert userCache.equals(FilesystemConfiguration.getCacheHome());
-	    	
-			assert AppFactory.desktopLinkExists(appName)==false;
-			
-			final Path desktop = Paths.get(JavaSystemProperties.getUserHome(), "Desktop" );
+
+		try {
+			System.setProperty(JavaSystemPropertiesConstants.USER_HOME, userHome);
+			assert userHome.equals(JavaSystemProperties.getUserHome());
+			updateCacheHome(userCache);
+			assert userCache.equals(FilesystemConfiguration.getCacheHome());
+
+			assert AppFactory.desktopLinkExists(appName) == false;
+
+			final Path desktop = Paths.get(JavaSystemProperties.getUserHome(), "Desktop");
 			Files.createDirectories(desktop);
 			assert Files.isDirectory(desktop);
-			
-			final Path link = desktop.resolve( appNameWithSuffix );
-		
-			{	// regular file 
-				assert Files.exists(link)==false;
+
+			final Path link = desktop.resolve(appNameWithSuffix);
+
+			{ // regular file
+				assert Files.exists(link) == false;
 				Files.createFile(link);
-				assert Files.exists(link)==true;
-				assert AppFactory.desktopLinkExists(appName)==false;
+				assert Files.exists(link) == true;
+				assert AppFactory.desktopLinkExists(appName) == false;
 				Files.delete(link);
 			}
-			
-			{	// directory 
-				assert Files.exists(link)==false;
+
+			{ // directory
+				assert Files.exists(link) == false;
 				Files.createDirectories(link);
-				assert Files.isDirectory(link)==true;
-				assert AppFactory.desktopLinkExists(appName)==false;
+				assert Files.isDirectory(link) == true;
+				assert AppFactory.desktopLinkExists(appName) == false;
 				Files.delete(link);
 			}
-			
-			final Path appRoot = AppFactory.createAppWithoutMenuEntry
-			(
-				appName, appNameWithSuffix, IcnsFactorySample.class.getResource("icon.png").getFile()
-			).toPath();
 
-			{	// wrong link 
-				assert Files.exists(link)==false;
+			final Path appRoot = AppFactory.createAppWithoutMenuEntry(appName, appNameWithSuffix,
+					IcnsFactorySample.class.getResource("icon.png").getFile()).toPath();
+
+			{ // wrong link
+				assert Files.exists(link) == false;
 				Files.createSymbolicLink(link, appRoot.resolve(AppFactory.CONTENTS_FOLDER_NAME));
-				assert Files.isSymbolicLink(link)==true;
-				assert AppFactory.desktopLinkExists(appName)==false;
+				assert Files.isSymbolicLink(link) == true;
+				assert AppFactory.desktopLinkExists(appName) == false;
 				Files.delete(link);
 			}
 
-			{	// wrong link 
-				assert Files.exists(link)==false;
+			{ // wrong link
+				assert Files.exists(link) == false;
 				Files.createSymbolicLink(link, appRoot);
-				assert Files.isSymbolicLink(link)==true;
-				assert AppFactory.desktopLinkExists(appName)==true;
+				assert Files.isSymbolicLink(link) == true;
+				assert AppFactory.desktopLinkExists(appName) == true;
 				Files.delete(link);
 			}
-		}
-		finally
-		{
+		} finally {
 			restoreOrigins();
 		}
 	}
 
 	@Test
-	public void testCreateDesktopLink() 
-		throws Exception
-	{
-		if ( !OperationSystem.getLocalSystem().equals(OperationSystem.MAC64) )
-		{
+	public void testCreateDesktopLink() throws Exception {
+		if (!OperationSystem.getLocalSystem().equals(OperationSystem.MAC64)) {
 			return;
 		}
 
 		FileUtils.recursiveDelete(new File(userHome), new File("/tmp"));
-		assert new File(userHome).exists()==false;
+		assert new File(userHome).exists() == false;
 
 		final String appName = "MyFirstApp";
 		final String appNameWithSuffix = appName + AppFactory.APP_EXTENSION;
-		
-		try
-		{
-	    	System.setProperty(JavaSystemPropertiesConstants.USER_HOME, userHome);
-	    	assert userHome.equals(JavaSystemProperties.getUserHome());
-	    	updateCacheHome(userCache);
-	    	assert userCache.equals(FilesystemConfiguration.getCacheHome());
 
-			final Path desktop = Paths.get(JavaSystemProperties.getUserHome(), "Desktop" );
+		try {
+			System.setProperty(JavaSystemPropertiesConstants.USER_HOME, userHome);
+			assert userHome.equals(JavaSystemProperties.getUserHome());
+			updateCacheHome(userCache);
+			assert userCache.equals(FilesystemConfiguration.getCacheHome());
+
+			final Path desktop = Paths.get(JavaSystemProperties.getUserHome(), "Desktop");
 			Files.createDirectories(desktop);
-			assert Files.isDirectory(desktop);		
-			
+			assert Files.isDirectory(desktop);
+
 			final Path link = desktop.resolve(appNameWithSuffix);
-			assert Files.exists(link)==false;
-			
+			assert Files.exists(link) == false;
+
 			AppFactory.createDesktopLink(appName, script, IcnsFactorySample.class.getResource("icon.png").getFile());
-			
+
 			assert Files.isSymbolicLink(link);
-		}
-		finally
-		{
+		} finally {
 			restoreOrigins();
 		}
 	}
-	
-	private final static void restoreOrigins()
-		throws Exception
-	{
-    	System.setProperty(JavaSystemPropertiesConstants.USER_HOME, originUserHome);
-    	assert originUserHome.equals(JavaSystemProperties.getUserHome());
-    	updateCacheHome(originCacheHome);
-    	assert originCacheHome.equals(FilesystemConfiguration.getCacheHome());
+
+	private final static void restoreOrigins() throws Exception {
+		System.setProperty(JavaSystemPropertiesConstants.USER_HOME, originUserHome);
+		assert originUserHome.equals(JavaSystemProperties.getUserHome());
+		updateCacheHome(originCacheHome);
+		assert originCacheHome.equals(FilesystemConfiguration.getCacheHome());
 	}
-	
+
 	@SuppressWarnings("unchecked")
-	private static void updateCacheHome( final String val ) 
-		throws ReflectiveOperationException 
-	{
+	private static void updateCacheHome(final String val) throws ReflectiveOperationException {
 		final Field field = FilesystemConfiguration.class.getDeclaredField("cacheHome");
 		field.setAccessible(true);
 		((AtomicReference<String>) field.get(null)).set(val);

--- a/openwebstart/src/test/java/com/openwebstart/os/mac/AppFactoryTest.java
+++ b/openwebstart/src/test/java/com/openwebstart/os/mac/AppFactoryTest.java
@@ -36,7 +36,7 @@ public final class AppFactoryTest extends Object {
 		}
 
 		FileUtils.recursiveDelete(new File(userHome), new File("/tmp"));
-		assert new File(userHome).exists() == false;
+		assertTrue(new File(userHome).exists() == false);
 
 		try {
 			System.setProperty(JavaSystemPropertiesConstants.USER_HOME, userHome);

--- a/openwebstart/src/test/java/com/openwebstart/os/mac/ScriptFactoryTest.java
+++ b/openwebstart/src/test/java/com/openwebstart/os/mac/ScriptFactoryTest.java
@@ -1,5 +1,7 @@
 package com.openwebstart.os.mac;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.net.URL;
 
 import org.junit.jupiter.api.Test;
@@ -15,14 +17,14 @@ class ScriptFactoryTest {
 		final JNLPFileFactory f = new JNLPFileFactory();
 		final URL jnlpUrl = this.getClass().getClassLoader()
 				.getResource("com/openwebstart/jnlp/with-http-location.jnlp");
-		assert jnlpUrl != null;
+		assertTrue(jnlpUrl != null);
 
 		final JNLPFile jnlp = f.create(jnlpUrl);
-		assert jnlp != null;
-		assert "http://localhost/jnlp.jnlp".equals(jnlp.getSourceLocation().toString());
+		assertTrue(jnlp != null);
+		assertTrue("http://localhost/jnlp.jnlp".equals(jnlp.getSourceLocation().toString()));
 
 		final String script = ScriptFactory.createSimpleStartScriptForMac(jnlp);
-		assert script.contains("open \"jnlp://localhost/jnlp.jnlp\"");
+		assertTrue(script.contains("open \"jnlp://localhost/jnlp.jnlp\""));
 	}
 
 	@Test
@@ -30,14 +32,14 @@ class ScriptFactoryTest {
 		final JNLPFileFactory f = new JNLPFileFactory();
 		final URL jnlpUrl = this.getClass().getClassLoader()
 				.getResource("com/openwebstart/jnlp/with-https-location.jnlp");
-		assert jnlpUrl != null;
+		assertTrue(jnlpUrl != null);
 
 		final JNLPFile jnlp = f.create(jnlpUrl);
-		assert jnlp != null;
-		assert "https://localhost/jnlp.jnlp".equals(jnlp.getSourceLocation().toString());
+		assertTrue(jnlp != null);
+		assertTrue("https://localhost/jnlp.jnlp".equals(jnlp.getSourceLocation().toString()));
 
 		final String script = ScriptFactory.createSimpleStartScriptForMac(jnlp);
-		assert script.contains("open \"jnlps://localhost/jnlp.jnlp\"");
+		assertTrue(script.contains("open \"jnlps://localhost/jnlp.jnlp\""));
 	}
 
 	@Test
@@ -45,13 +47,13 @@ class ScriptFactoryTest {
 		final JNLPFileFactory f = new JNLPFileFactory();
 		final URL jnlpUrl = this.getClass().getClassLoader()
 				.getResource("com/openwebstart/jnlp/with-file-location.jnlp");
-		assert jnlpUrl != null;
+		assertTrue(jnlpUrl != null);
 
 		final JNLPFile jnlp = f.create(jnlpUrl);
-		assert jnlp != null;
-		assert "file:/path/jnlp.jnlp".equals(jnlp.getSourceLocation().toString());
+		assertTrue(jnlp != null);
+		assertTrue("file:/path/jnlp.jnlp".equals(jnlp.getSourceLocation().toString()));
 
 		final String script = ScriptFactory.createSimpleStartScriptForMac(jnlp);
-		assert script.contains("open \"file:/path/jnlp.jnlp\"");
+		assertTrue(script.contains("open \"file:/path/jnlp.jnlp\""));
 	}
 }

--- a/openwebstart/src/test/java/com/openwebstart/os/mac/ScriptFactoryTest.java
+++ b/openwebstart/src/test/java/com/openwebstart/os/mac/ScriptFactoryTest.java
@@ -9,52 +9,48 @@ import com.openwebstart.os.ScriptFactory;
 import net.sourceforge.jnlp.JNLPFile;
 import net.sourceforge.jnlp.JNLPFileFactory;
 
-class ScriptFactoryTest 
-{
+class ScriptFactoryTest {
 	@Test
-	void testCreateStartScriptForMac_for_http_location()  
-		throws Exception
-	{
+	void testCreateStartScriptForMac_for_http_location() throws Exception {
 		final JNLPFileFactory f = new JNLPFileFactory();
-		final URL jnlpUrl = this.getClass().getClassLoader().getResource("com/openwebstart/jnlp/with-http-location.jnlp");
-		assert jnlpUrl!=null;
-		
+		final URL jnlpUrl = this.getClass().getClassLoader()
+				.getResource("com/openwebstart/jnlp/with-http-location.jnlp");
+		assert jnlpUrl != null;
+
 		final JNLPFile jnlp = f.create(jnlpUrl);
-		assert jnlp!=null;
+		assert jnlp != null;
 		assert "http://localhost/jnlp.jnlp".equals(jnlp.getSourceLocation().toString());
-		
+
 		final String script = ScriptFactory.createSimpleStartScriptForMac(jnlp);
 		assert script.contains("open \"jnlp://localhost/jnlp.jnlp\"");
 	}
 
 	@Test
-	void testCreateStartScriptForMac_for_https_location()  
-		throws Exception
-	{
+	void testCreateStartScriptForMac_for_https_location() throws Exception {
 		final JNLPFileFactory f = new JNLPFileFactory();
-		final URL jnlpUrl = this.getClass().getClassLoader().getResource("com/openwebstart/jnlp/with-https-location.jnlp");
-		assert jnlpUrl!=null;
-		
+		final URL jnlpUrl = this.getClass().getClassLoader()
+				.getResource("com/openwebstart/jnlp/with-https-location.jnlp");
+		assert jnlpUrl != null;
+
 		final JNLPFile jnlp = f.create(jnlpUrl);
-		assert jnlp!=null;
+		assert jnlp != null;
 		assert "https://localhost/jnlp.jnlp".equals(jnlp.getSourceLocation().toString());
-		
+
 		final String script = ScriptFactory.createSimpleStartScriptForMac(jnlp);
 		assert script.contains("open \"jnlps://localhost/jnlp.jnlp\"");
 	}
 
 	@Test
-	void testCreateStartScriptForMac_for_file_location()  
-		throws Exception
-	{
+	void testCreateStartScriptForMac_for_file_location() throws Exception {
 		final JNLPFileFactory f = new JNLPFileFactory();
-		final URL jnlpUrl = this.getClass().getClassLoader().getResource("com/openwebstart/jnlp/with-file-location.jnlp");
-		assert jnlpUrl!=null;
-		
+		final URL jnlpUrl = this.getClass().getClassLoader()
+				.getResource("com/openwebstart/jnlp/with-file-location.jnlp");
+		assert jnlpUrl != null;
+
 		final JNLPFile jnlp = f.create(jnlpUrl);
-		assert jnlp!=null;
+		assert jnlp != null;
 		assert "file:/path/jnlp.jnlp".equals(jnlp.getSourceLocation().toString());
-		
+
 		final String script = ScriptFactory.createSimpleStartScriptForMac(jnlp);
 		assert script.contains("open \"file:/path/jnlp.jnlp\"");
 	}

--- a/openwebstart/src/test/java/com/openwebstart/os/mac/ScriptFactoryTest.java
+++ b/openwebstart/src/test/java/com/openwebstart/os/mac/ScriptFactoryTest.java
@@ -1,0 +1,61 @@
+package com.openwebstart.os.mac;
+
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+import com.openwebstart.os.ScriptFactory;
+
+import net.sourceforge.jnlp.JNLPFile;
+import net.sourceforge.jnlp.JNLPFileFactory;
+
+class ScriptFactoryTest 
+{
+	@Test
+	void testCreateStartScriptForMac_for_http_location()  
+		throws Exception
+	{
+		final JNLPFileFactory f = new JNLPFileFactory();
+		final URL jnlpUrl = this.getClass().getClassLoader().getResource("com/openwebstart/jnlp/with-http-location.jnlp");
+		assert jnlpUrl!=null;
+		
+		final JNLPFile jnlp = f.create(jnlpUrl);
+		assert jnlp!=null;
+		assert "http://localhost/jnlp.jnlp".equals(jnlp.getSourceLocation().toString());
+		
+		final String script = ScriptFactory.createSimpleStartScriptForMac(jnlp);
+		assert script.contains("open \"jnlp://localhost/jnlp.jnlp\"");
+	}
+
+	@Test
+	void testCreateStartScriptForMac_for_https_location()  
+		throws Exception
+	{
+		final JNLPFileFactory f = new JNLPFileFactory();
+		final URL jnlpUrl = this.getClass().getClassLoader().getResource("com/openwebstart/jnlp/with-https-location.jnlp");
+		assert jnlpUrl!=null;
+		
+		final JNLPFile jnlp = f.create(jnlpUrl);
+		assert jnlp!=null;
+		assert "https://localhost/jnlp.jnlp".equals(jnlp.getSourceLocation().toString());
+		
+		final String script = ScriptFactory.createSimpleStartScriptForMac(jnlp);
+		assert script.contains("open \"jnlps://localhost/jnlp.jnlp\"");
+	}
+
+	@Test
+	void testCreateStartScriptForMac_for_file_location()  
+		throws Exception
+	{
+		final JNLPFileFactory f = new JNLPFileFactory();
+		final URL jnlpUrl = this.getClass().getClassLoader().getResource("com/openwebstart/jnlp/with-file-location.jnlp");
+		assert jnlpUrl!=null;
+		
+		final JNLPFile jnlp = f.create(jnlpUrl);
+		assert jnlp!=null;
+		assert "file:/path/jnlp.jnlp".equals(jnlp.getSourceLocation().toString());
+		
+		final String script = ScriptFactory.createSimpleStartScriptForMac(jnlp);
+		assert script.contains("open \"file:/path/jnlp.jnlp\"");
+	}
+}

--- a/openwebstart/src/test/resources/com/openwebstart/jnlp/with-file-location.jnlp
+++ b/openwebstart/src/test/resources/com/openwebstart/jnlp/with-file-location.jnlp
@@ -1,0 +1,50 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!-- this is a sample jnlp file -->
+<jnlp spec='1.0'
+    codebase='file:/path/'
+    href='jnlp.jnlp'>
+  <information>
+    <!-- this is the information section -->
+    <title>Large JNLP</title>
+    <vendor>The IcedTea Project</vendor>
+    <homepage href='http://homepage/' />
+    <description kind='one-line'>one-line</description>
+    <description kind='short'>short</description>
+    <description kind='tooltip'>tooltip</description>
+    <icon href='icon.png' />
+    <icon href='splash.png' kind='splash' />
+    <offline-allowed />
+    <shortcut online='true'>
+      <desktop/>
+      <menu submenu='submenu'/>
+    </shortcut>
+    <association extensions='*.foo' mime-type='foo/bar'>
+      <description>description of association</description>
+      <icon href='icon.png' />
+    </association>
+    <related-content href='http://related-content/'>
+      <title>related-content <!-- or something -->title</title>
+      <description>description of related-content</description>
+      <icon href='related-content-icon.png' />
+    </related-content>
+  </information>
+  <security>
+    <all-permissions/>
+  </security>
+  <resources>
+    <!-- the resources section describes things needed -->
+    <java version='1.3+' href='http://java-url/'
+        initial-heap-size='64m'
+        max-heap-size='128m' />
+    <jar href='eager.jar' download='eager'/>
+    <jar href='lazy.jar' download='lazy'/>
+    <nativelib href='native.jar'/>
+    <extension name='extension' version='0.1.1' href='http://extension/'/>
+    <property name='key' value='value'/>
+  </resources>
+  <application-desc main-class='MainClass'>
+    <argument>arg1</argument>
+    <argument>arg2</argument>
+  </application-desc>
+</jnlp>
+

--- a/openwebstart/src/test/resources/com/openwebstart/jnlp/with-http-location.jnlp
+++ b/openwebstart/src/test/resources/com/openwebstart/jnlp/with-http-location.jnlp
@@ -1,0 +1,50 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!-- this is a sample jnlp file -->
+<jnlp spec='1.0'
+    codebase='http://localhost/'
+    href='jnlp.jnlp'>
+  <information>
+    <!-- this is the information section -->
+    <title>Large JNLP</title>
+    <vendor>The IcedTea Project</vendor>
+    <homepage href='http://homepage/' />
+    <description kind='one-line'>one-line</description>
+    <description kind='short'>short</description>
+    <description kind='tooltip'>tooltip</description>
+    <icon href='icon.png' />
+    <icon href='splash.png' kind='splash' />
+    <offline-allowed />
+    <shortcut online='true'>
+      <desktop/>
+      <menu submenu='submenu'/>
+    </shortcut>
+    <association extensions='*.foo' mime-type='foo/bar'>
+      <description>description of association</description>
+      <icon href='icon.png' />
+    </association>
+    <related-content href='http://related-content/'>
+      <title>related-content <!-- or something -->title</title>
+      <description>description of related-content</description>
+      <icon href='related-content-icon.png' />
+    </related-content>
+  </information>
+  <security>
+    <all-permissions/>
+  </security>
+  <resources>
+    <!-- the resources section describes things needed -->
+    <java version='1.3+' href='http://java-url/'
+        initial-heap-size='64m'
+        max-heap-size='128m' />
+    <jar href='eager.jar' download='eager'/>
+    <jar href='lazy.jar' download='lazy'/>
+    <nativelib href='native.jar'/>
+    <extension name='extension' version='0.1.1' href='http://extension/'/>
+    <property name='key' value='value'/>
+  </resources>
+  <application-desc main-class='MainClass'>
+    <argument>arg1</argument>
+    <argument>arg2</argument>
+  </application-desc>
+</jnlp>
+

--- a/openwebstart/src/test/resources/com/openwebstart/jnlp/with-https-location.jnlp
+++ b/openwebstart/src/test/resources/com/openwebstart/jnlp/with-https-location.jnlp
@@ -1,0 +1,50 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!-- this is a sample jnlp file -->
+<jnlp spec='1.0'
+    codebase='https://localhost/'
+    href='jnlp.jnlp'>
+  <information>
+    <!-- this is the information section -->
+    <title>Large JNLP</title>
+    <vendor>The IcedTea Project</vendor>
+    <homepage href='http://homepage/' />
+    <description kind='one-line'>one-line</description>
+    <description kind='short'>short</description>
+    <description kind='tooltip'>tooltip</description>
+    <icon href='icon.png' />
+    <icon href='splash.png' kind='splash' />
+    <offline-allowed />
+    <shortcut online='true'>
+      <desktop/>
+      <menu submenu='submenu'/>
+    </shortcut>
+    <association extensions='*.foo' mime-type='foo/bar'>
+      <description>description of association</description>
+      <icon href='icon.png' />
+    </association>
+    <related-content href='http://related-content/'>
+      <title>related-content <!-- or something -->title</title>
+      <description>description of related-content</description>
+      <icon href='related-content-icon.png' />
+    </related-content>
+  </information>
+  <security>
+    <all-permissions/>
+  </security>
+  <resources>
+    <!-- the resources section describes things needed -->
+    <java version='1.3+' href='http://java-url/'
+        initial-heap-size='64m'
+        max-heap-size='128m' />
+    <jar href='eager.jar' download='eager'/>
+    <jar href='lazy.jar' download='lazy'/>
+    <nativelib href='native.jar'/>
+    <extension name='extension' version='0.1.1' href='http://extension/'/>
+    <property name='key' value='value'/>
+  </resources>
+  <application-desc main-class='MainClass'>
+    <argument>arg1</argument>
+    <argument>arg2</argument>
+  </application-desc>
+</jnlp>
+


### PR DESCRIPTION
1. Application bundle is installed in ~/Applications and not in /Applications folder. Generally, not all users have permissions to install into /Applications.
2. Application start script [start.sh] does not refer [OpenWebstart] installation but simply calls `open `with jnlp-url allowing operating system to decide how to open given url. This keeps app-bundle working even if OpenWebStart installation folder has changed. It will work with any available jnlp-url-handler for example with oracle webstart. 
3. Application bundle is installed in ~/.cache/applications.
4. Application menu link is created in ~/Application folder and is just a symbolic link to app-bundle from ~/.cache/application folder.
5. Desktop link is just a symbolic link to app-bundle from ~/.cache/applications folder. 