### PR TITLE
ensure that ServerWhitelistDialog opens on top

### DIFF
--- a/openwebstart/src/main/java/com/openwebstart/jvm/ui/dialogs/JVMServerWhitelistDialog.java
+++ b/openwebstart/src/main/java/com/openwebstart/jvm/ui/dialogs/JVMServerWhitelistDialog.java
@@ -19,6 +19,7 @@ public class JVMServerWhitelistDialog extends ModalDialog {
     private final Translator translator = Translator.getInstance();
 
     public JVMServerWhitelistDialog(final DeploymentConfiguration deploymentConfiguration) {
+        setAlwaysOnTop(true);
         setTitle(translator.translate("dialog.jvmManagerWhitelist.title"));
 
         JButton closeButton = new JButton(translator.translate("action.close"));


### PR DESCRIPTION
without this at least on Mac the ServerWhitelistDialog otherwise pops up behind the ConfigurationDialog